### PR TITLE
Rewrite tooltips of objects

### DIFF
--- a/levels/attic/poing-poing-poing.xml
+++ b/levels/attic/poing-poing-poing.xml
@@ -8,9 +8,9 @@
         <date>June 6, 2010</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="3" name="Something weird">
+        <toolboxitem count="3" name="Peg">
             <object width="0.14" X="1.0" Y="2.7" height="0.14" type="CustomBall">
-                <tooltip>It's shiny and it hangs in the sky.</tooltip>
+                <tooltip>A round obstacle which is attached to the scene.</tooltip>
                 <property key="Radius">0.07</property>
                 <property key="Bounciness">0.7</property>
                 <property key="ImageName">brass-pin</property>
@@ -52,8 +52,8 @@
                 <property key="page2">Volley balls can do that, too.&lt;br>&lt;br>Wanna bet?</property>
                 <property key="page3">Both pins have to go down.</property>
                 <property key="page4">&lt;br> &lt;br> the Post-It Boy </property>
-                <property key="page5">By the way: it is possible with only one of those weird thingies!</property>
-                <property key="page6">And you already realized that the weird thingies can adjust the trajectories of both the ball and the bottle, right?</property>
+                <property key="page5">By the way: it is possible with only one of those pegs!</property>
+                <property key="page6">And you already realized that the pegs can adjust the trajectories of both the ball and the bottle, right?</property>
             </object>
             <object width="5.0" X="2.5" Y="0.05" height="0.1" type="RectObject">
                 <property key="ImageName">used_wood_bar</property>

--- a/levels/draft/cola_reaction.xml
+++ b/levels/draft/cola_reaction.xml
@@ -73,7 +73,7 @@
             <object type="Floor" X="3.018" Y="2.924" width="0.586" height="0.100" angle="0.000"/>
             <object type="PostIt" X="3.101" Y="2.717" width="0.220" height="0.220" angle="0.000">
                 <property key="ZValue">1</property>
-                <property key="page1">Do you see the weird pin from which the weight is hanging?</property>
+                <property key="page1">Do you see the weird peg from which the weight is hanging?</property>
                 <property key="page2">It lies in a guide rail, it can move freely left and right.</property>
                 <property key="page3">But why would anyone need a hanging weight here, anyways?</property>
                 <property key="page4">—Post-it boy</property>

--- a/levels/draft/dialbforboom.xml
+++ b/levels/draft/dialbforboom.xml
@@ -49,11 +49,13 @@
                 <property key="Mass">1.0</property>
             </object>
             <object width="0.100" X="2.880" Y="0.925" height="0.250" type="Balloon" angle="0.000">
+                <tooltip>The famous blue plastic domino stone.</tooltip>
                 <property key="Polygons">(-0.11,0.175)=(-0.11,-0.175)=(0.11,-0.175)=(0.11,0.175)</property>
                 <property key="ImageName">DominoBlue;Empty;Empty;Empty</property>
                 <property key="Mass">1.0</property>
             </object>
             <object width="0.100" X="3.110" Y="1.175" height="0.250" type="Balloon" angle="0.000">
+                <tooltip>The famous blue plastic domino stone.</tooltip>
                 <property key="Polygons">(-0.11,0.175)=(-0.11,-0.175)=(0.11,-0.175)=(0.11,0.175)</property>
                 <property key="ImageName">DominoBlue;Empty;Empty;Empty</property>
                 <property key="Mass">1.0</property>

--- a/levels/games/extreme-tux-racer.xml
+++ b/levels/games/extreme-tux-racer.xml
@@ -32,6 +32,7 @@
                 <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.600" X="1.169" Y="3.481" height="0.250" type="RectObject" ID="penguin" angle="0.000">
+                <tooltip>This is Tux, he looks a bit sleepy. Wake him up with something!</tooltip>
                 <property key="ImageName">penguin_gliding</property>
                 <property key="Mass">1.5</property>
                 <property key="Friction">0.1</property>
@@ -78,6 +79,7 @@
                 <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.300" X="1.340" Y="3.760" height="0.300" type="Balloon" angle="0.000">
+                <tooltip></tooltip>
                 <property key="ImageName">zzz;Empty;Empty;Empty</property>
                 <property key="Mass">2</property>
                 <property key="Polygons">(-0.1,0.1)=(-0.1,-0.1)=(0.1,-0.1)=(0.1,0.1)</property>

--- a/levels/picnic/picnic-2.xml
+++ b/levels/picnic/picnic-2.xml
@@ -8,8 +8,9 @@
         <date>5/7/12</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="3" name="Something weird">
+        <toolboxitem count="3" name="Peg">
             <object width="0.14" X="1.0" Y="2.7" height="0.14" type="CustomBall">
+                <tooltip>A round obstacle which is attached to the scene.</tooltip>
                 <property key="Radius">0.07</property>
                 <property key="Bounciness">0.7</property>
                 <property key="ImageName">brass-pin</property>

--- a/src/model/BalloonCactus.cpp
+++ b/src/model/BalloonCactus.cpp
@@ -56,7 +56,7 @@ const qreal Balloon::POPPED_TIME  = 2.0;
 
 Balloon::Balloon()
 		: PolyObject(QObject::tr("Balloon"),
-					 QObject::tr("a Helium Balloon. Lighter than air, it moves up."),
+					 QObject::tr("A helium balloon. Lighter than air, it moves up.\nIt will pop when it hits sharp objects or gets squashed."),
 					 "Balloon;BalloonPoof;BalloonRest;Empty",
 					 "(-0.018,0.18)=(-0.07,0.16)=(-0.12,0.1)=(-0.13,0.017)=(-0.1,-0.08)"
 					 "=(-0.03,-0.16)=(0.006,-0.17)=(0.039,-0.16)=(0.10,-0.08)"
@@ -264,7 +264,7 @@ static CactusObjectFactory theCactusObjectFactory;
 
 
 Cactus::Cactus() : PolyObject(QObject::tr("Cactus"),
-							  QObject::tr("Cactacea Bulbuous Stingus - a Cactus has spines!"),
+							  QObject::tr("Cactus (Cactacea Bulbuous Stingus):\nA cactus has sharp spines."),
 							  "Cactus",
 							  // first the pot:
 							  "(-0.105,-0.038)=(-0.05,-0.2)=(0.05,-0.2)=(0.105,-0.038);"
@@ -342,7 +342,7 @@ static BedOfNailsObjectFactory theBedOfNailsObjectFactory;
 
 BedOfNails::BedOfNails()
 		: PolyObject(QObject::tr("BedOfNails"),
-					 QObject::tr("Do not touch a bed of nails - it stings!"),
+					 QObject::tr("A wooden board attached to the scene.\nIt has many sharp nails on one side."),
 					 "BedOfNails",
 					 // first the bar:
 					 "(-0.4,-0.075)=(0.4,-0.075)=(0.4,0.006)=(-0.4,0.006);"
@@ -412,7 +412,7 @@ static CircularSawObjectFactory theCircularSawObjectFactory;
 
 CircularSaw::CircularSaw()
 		: CircleObject(QObject::tr("CircularSaw"),
-					 QObject::tr("a rotating disc with sharp teeth."),
+					 QObject::tr("A rotating disc with sharp teeth."),
 					 "CircularSaw",
 					 CIRCRADIUS, CIRCMASS, 0.1)
 {

--- a/src/model/Butterfly.cpp
+++ b/src/model/Butterfly.cpp
@@ -42,7 +42,7 @@ const double Butterfly::theButterflyMass = 0.01;
 Butterfly::Butterfly()
         : RectObject(), theCountdown(1)
 {
-    theToolTip = QObject::tr("Butterfly (Flappus Chaoticus Fragilius) - always in search of flowers.");
+    theToolTip = QObject::tr("Butterfly (Flappus Chaoticus Fragilius):\nIt slowly flies to the right and is attracted\nto flowers. It is very fragile.\nYou have to keep it save at all costs!");
 	theProps.setDefaultPropertiesString(
 			Property::OBJECT_STRING + QString(":/") +
 			Property::BOUNCINESS_STRING + QString(":0/") +

--- a/src/model/CircleObjects.cpp
+++ b/src/model/CircleObjects.cpp
@@ -27,13 +27,13 @@
 // the non-uniform weight distribution in the ball - we assume it to be uniform
 static CircleObjectFactory theBBFactory("BowlingBall",
     QT_TRANSLATE_NOOP("CircleObjectFactory", "Bowling Ball"),
-    QT_TRANSLATE_NOOP("CircleObjectFactory", "Your average bowling ball - heavy, round and willing to roll"),
+    QT_TRANSLATE_NOOP("CircleObjectFactory", "Your average bowling ball: heavy, round and willing to roll."),
 	"BowlingBall", 0.11, 6.0, 0.1 );
 
 // we are lazy and do not model the air, we assume it to be uniform in mass
 static CircleObjectFactory theVBFactory("VolleyBall",
-    QT_TRANSLATE_NOOP("CircleObjectFactory", "Volley Ball"),
-    QT_TRANSLATE_NOOP("CircleObjectFactory", "A volley ball - you know: light, soft and fairly bouncy."),
+    QT_TRANSLATE_NOOP("CircleObjectFactory", "Volleyball"),
+    QT_TRANSLATE_NOOP("CircleObjectFactory", "A volleyball—you know: light, soft and very bouncy."),
 	"VolleyBall", 0.105, 0.280, 0.65);
 
 
@@ -42,7 +42,7 @@ static CircleObjectFactory theVBFactory("VolleyBall",
 // we are lazy and do not model the air, we assume it to be uniform in mass
 static CircleObjectFactory theTBFactory("TennisBall",
     QT_TRANSLATE_NOOP("CircleObjectFactory", "Tennis Ball"),
-    QT_TRANSLATE_NOOP("CircleObjectFactory", "A tennis ball is small, fuzzy and known for turning heads."),
+    QT_TRANSLATE_NOOP("CircleObjectFactory", "A tennis ball is small, fuzzy and bouncy."),
 	"TennisBall", 0.034, 0.058, 0.56);
 
 // the official standards say that a soccer is 68-70cm circumference and weighs 410-450 grams
@@ -50,7 +50,7 @@ static CircleObjectFactory theTBFactory("TennisBall",
 // we are lazy and do not model the air, we assume it to be uniform in mass
 static CircleObjectFactory theSoccerFactory("SoccerBall",
     QT_TRANSLATE_NOOP("CircleObjectFactory", "Soccer Ball"),
-    QT_TRANSLATE_NOOP("CircleObjectFactory", "A football (of the spherical persuasion)."),
+    QT_TRANSLATE_NOOP("CircleObjectFactory", "A soccer ball is large and bouncy."),
 	"SoccerBall", 0.110, 0.430, 0.56);
 
 // there is not much of official standards for a petanque ball, but
@@ -58,7 +58,7 @@ static CircleObjectFactory theSoccerFactory("SoccerBall",
 // diameter between 70.5 and 80mm, weight between 650 and 800 grams.
 static CircleObjectFactory thePetanqueFactory("PetanqueBoule",
     QT_TRANSLATE_NOOP_UTF8("CircleObjectFactory", "Pétanque Boule"),
-    QT_TRANSLATE_NOOP_UTF8("CircleObjectFactory", "A pétanque ball is made of metal and heavy."),
+    QT_TRANSLATE_NOOP_UTF8("CircleObjectFactory", "A pétanque ball is made of metal and is quite heavy."),
 	"PetanqueBoule", 0.038, 0.700, 0.1);
 
 // Constructors/Destructors

--- a/src/model/ColaMintBottle.cpp
+++ b/src/model/ColaMintBottle.cpp
@@ -47,7 +47,7 @@ static const float BOTTLEHEIGHT=0.50;
 
 ColaMintBottle::ColaMintBottle()
 		: PolyObject(QObject::tr("Cola+Mint Bottle"),
-					 QObject::tr("This is a prepared cola bottle with a mint in it.\nLook: it blows if triggered!"),
+					 QObject::tr("This is a prepared cola bottle with a mint in it.\nIf you shake it just a little bit, a reaction starts,\nwhich causes the bottle to fire a long stream\nof cola which pushes the bottle and light\nobjects around."),
 					 "ColaBottleNormal;ColaBottleFoaming;ColaBottleBlowing;ColaBottleEmpty",
 					 "(-0.01,0.25)=(-0.083,0.12)=(-0.075,-0.234)=(-0.060,-0.25)"
 					 "=(0.060,-0.25)=(0.075,-0.234)=(0.083,0.12)=(0.01,0.25)",

--- a/src/model/Pingus.cpp
+++ b/src/model/Pingus.cpp
@@ -51,7 +51,7 @@ int Pingus::theAliveCount = 0;
 
 Pingus::Pingus()
 		: CircleObject(QObject::tr("Pingus"),
-					 QObject::tr("The famous penguin. He walks and believes in your guidance. Keep him alive!"),
+					 QObject::tr("A penguin walks left or right and turns around when\nit collides with something heavy. It and can push\nlight objects around. It also likes to slide down\nslopes but can't take much abuse."),
 					 "",
                      PINGUS_RADIUS, PINGUS_MASS, 0.0 )
 {

--- a/src/model/PolyObject.cpp
+++ b/src/model/PolyObject.cpp
@@ -46,8 +46,8 @@ static AbstractPolyObjectFactory theBowlingPinFactory(
 	"BowlingPin",
 	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Bowling Pin"),
 	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Bowling pins are meant to be run "
-				"over - most\npeople prefer to do that using "
-				"a Bowling Ball."),
+				"over—most\npeople prefer to do that using "
+				"a bowling ball."),
 	"BowlingPin",
 	"(0.02,0.17)=(-0.02,0.17)=(-0.045,0.14)=(-0.04,0.065)=(0.0,0.04)"
 	"=(0.04,0.065)=(0.045,0.14);"
@@ -68,7 +68,7 @@ static AbstractPolyObjectFactory theSkyhookFactory(
 static AbstractPolyObjectFactory theWeightFactory(
 	"Weight",
 	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Weight"),
-	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "A serious mass. As heavy as it looks!"),
+	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "A serious mass. It is very heavy."),
 	"Weight",
 	"(-0.20,-0.20)=(0.20,-0.20)=(0.06,0.20)=(-0.06,0.20)",
 	0.40, 0.40, 10.0, 0.3 );
@@ -110,7 +110,7 @@ static AbstractPolyObjectFactory theRightWedgeFactory(
 static AbstractPolyObjectFactory the40QuarterArcFactory(
 	"QuarterArc40",
 	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Quarter Arc Small"),
-	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "This is a quarter arc. Or ninety degrees, or 1.57 radians if you want."),
+	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "This quarter arc is attached to the scene.\nIt can't be moved, penetrated or destroyed."),
 	"QuarterArc",
 	"(0.100,-.200)=(0.200,-.200)=(0.180,-.076)=(0.085,-.107);"
 	"(0.085,-.107)=(0.180,-.076)=(0.124,0.035)=(0.043,-.024);"
@@ -124,7 +124,7 @@ static AbstractPolyObjectFactory the40QuarterArcFactory(
 static AbstractPolyObjectFactory the80QuarterArcFactory(
 	"QuarterArc80",
 	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Quarter Arc Large"),
-	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "This is a quarter arc. Or ninety degrees, or 1.57 radians if you want."),
+	QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "This quarter arc is attached to the scene.\nIt can't be moved, penetrated or destroyed."),
 	"QuarterArc80",
 	"( 0.300,-0.400)=( 0.400,-0.400)=( 0.388,-0.261)=( 0.289,-0.278);"
 	"( 0.289,-0.278)=( 0.388,-0.261)=( 0.352,-0.126)=( 0.258,-0.161);"

--- a/src/model/PostIt.cpp
+++ b/src/model/PostIt.cpp
@@ -50,8 +50,8 @@ PostIt::PostIt( )
 			QString("-") + Property::IMAGE_NAME_STRING + QString(":/") +
 			"-" + Property::MASS_STRING + QString(":/") );
     theToolTip = QObject::tr("Someone left notes all over the place.\n"
-                             "You know, those yellow 3x3 inch pieces of paper.\n"
-                             "You might want to read them - it may help!");
+                             "You know, those yellow 3×3 inch pieces of paper.\n"
+                             "You might want to read them—it may help!");
 
 	DEBUG5("PostIt::PostIt done");
 }

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -56,40 +56,40 @@ static AbstractRectObjectFactory theBirchBarFactory("BirchBar",
 
 static AbstractRectObjectFactory theDomRedFactory("DominoRed",
 	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Red)"),
-	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous plastic red domino stone"),
+	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous plastic red domino stone."),
 	"DominoRed", 0.1, 0.5, 2.5, 0.1 );
 
 static AbstractRectObjectFactory theDomBlueFactory("DominoBlue",
 	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Blue)"),
-	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous plastic blue domino stone"),
+	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous plastic blue domino stone."),
 	"DominoBlue", 0.1, 0.5, 2.5, 0.1 );
 
 static AbstractRectObjectFactory theDomGreenFactory("DominoGreen",
 	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Green)"),
-	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous plastic green domino stone"),
+	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous plastic green domino stone."),
 	"DominoGreen", 0.1, 0.5, 2.5, 0.1 );
 
 static AbstractRectObjectFactory theFloorFactory("Floor",
 	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Floor"),
-	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "It doesn't move."),
+	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "This is the floor. It is attached to the scene\nand can't be moved, penetrated or destroyed."),
 	"used_wood_bar", 1.0, 0.1, 0.0, 0.1 );
 
 // see http://www.saginawpipe.com/steel_i_beams.htm
 // a 4"x4" beam weighs 13 pounds per feet, i.e. a 1.4m beam weighs 27kg.
 static AbstractRectObjectFactory theSteelHBeamFactory("IBeam",
 	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Steel I-Beam"),
-	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "An I Beam is named after the shape of its cross-section.\n It's heavy, don't drop one on your foot."),
+	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "This is a steel I-beam. Steel I-beams are large and heavy\nand useful to build bridges and other constructions."),
 	"i-beam", 1.4, 0.1, 27.0, 0.0 );
 
 static AbstractRectObjectFactory theWallFactory("Wall",
 	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Wall"),
-	"",
+	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "This is a brick wall. It is attached to the scene\nand can't be moved, penetrated or destroyed."),
 	"oldbrick", 0.2, 1.0, 0.0, 0.05 );
 
 // Note that this hammer is kind-of heavy, a normal hammer would be around 400 grams, only
 static AbstractRectObjectFactory theHammerFactory("Hammer",
 	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Hammer"),
-	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "A hammer usually has a hickory handle and a steel head."),
+	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "This is a hammer which has been attached\nto the scene at the end of its handle.\nThe hammer can be used to apply a force\nto some of the heavier objects."),
 	"hammer", 0.45,0.18, 2.0, 0.0,
 	"Friction:0.0/PivotPoint:(0.2,0)/");
 

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -56,17 +56,17 @@ static AbstractRectObjectFactory theBirchBarFactory("BirchBar",
 
 static AbstractRectObjectFactory theDomRedFactory("DominoRed",
 	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Red)"),
-	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous plastic red domino stone."),
+	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous red plastic domino stone."),
 	"DominoRed", 0.1, 0.5, 2.5, 0.1 );
 
 static AbstractRectObjectFactory theDomBlueFactory("DominoBlue",
 	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Blue)"),
-	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous plastic blue domino stone."),
+	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous blue plastic domino stone."),
 	"DominoBlue", 0.1, 0.5, 2.5, 0.1 );
 
 static AbstractRectObjectFactory theDomGreenFactory("DominoGreen",
 	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Green)"),
-	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous plastic green domino stone."),
+	QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous green plastic domino stone."),
 	"DominoGreen", 0.1, 0.5, 2.5, 0.1 );
 
 static AbstractRectObjectFactory theFloorFactory("Floor",

--- a/src/model/Spring.cpp
+++ b/src/model/Spring.cpp
@@ -74,7 +74,7 @@ static SpringObjectFactory theSpringObjectFactory;
 
 Spring::Spring()
     :	RectObject( QObject::tr("Spring"),
-                    QObject::tr("Something springy."),
+                    QObject::tr("A loose spring. When a force is applied to it, it retracts\nand expands which will make things bounce off from it."),
                     "spring20",
                     0.4, 0.2, 0.8, 0.0),
       theOtherEndPtr(nullptr),

--- a/src/model/TriggerExplosion.cpp
+++ b/src/model/TriggerExplosion.cpp
@@ -151,8 +151,15 @@ QString DetonatorBox::getEmptyString() const
 
 const QString DetonatorBox::getToolTip ( ) const
 {
-	//: Translators: The %1 will be replaced by a phone number.
-	return QObject::tr("Send BOOM to %1").arg(getCurrentPhoneNumber());
+	QString part1 = QObject::tr("This is a detonator box attached to a cell phone\nto trigger a dynamite remotely by pushing the handle.\n");
+	QString part2;
+	if (getCurrentPhoneNumber() == getEmptyString())
+		part2 = QObject::tr("This one doesn't make any calls,\nchoose a phone number with the pie menu!");
+	else
+		//: Translators: The %1 will be replaced by a phone number.
+		part2 = QObject::tr("This one calls %1.").arg(getCurrentPhoneNumber());
+	QString ret = part1 + part2;
+	return ret;
 }
 
 qreal DetonatorBox::getZValue(void)
@@ -222,7 +229,7 @@ void DetonatorBox::updateViewObject(bool isSimRunning) const
 
 DetonatorBoxHandle::DetonatorBoxHandle(DetonatorBox* aDBox)
 	:	RectObject( QObject::tr("Detonator Box Handle"),
-					QObject::tr("Push Here To BOOM"),
+					QObject::tr("This is the handle of a detonator box.\nThrow a heavy object on it to push it."),
 					"DetonatorBoxHandle",
                     0.25, 0.20, 0.1, 0.0), theDBoxPtr(aDBox), theJointPtr(nullptr)
 {
@@ -417,8 +424,13 @@ void Dynamite::explode(void)
 
 const QString Dynamite::getToolTip ( ) const
 {
-	//: Translators: the \n means "newline" - keep it. The %1 will be replaced by a phone number
-	return QObject::tr("Dynamite: invented by Alfred Nobel. \n Dial %1 for a nice explosion.").arg(getID());
+	if(getID().isNull() || getID().isEmpty()) {
+		//: Translators: “\n” means “newline”, keep it.
+		return QObject::tr("It's dynamite attached to a cell phone.\nThis cell phone doesn't take any calls, however.");
+	} else {
+		//: Translators: “\n” means “newline”, keep it. “%1” will be replaced by the phone number
+		return QObject::tr("It's dynamite attached to a cell phone, ready to be\nremotely triggered by a detonator box.\nDial %1 to make the dynamite go boom.").arg(getID());
+	}
 }
 
 Dynamite::States Dynamite::goToState(Dynamite::States aNewState)

--- a/src/view/ChoosePhoneNumber.cpp
+++ b/src/view/ChoosePhoneNumber.cpp
@@ -72,5 +72,8 @@ void ChoosePhoneNumber::on_comboBox_activated()
 
 	// let's notify the detonator box
 	assert(theDBPtr!=nullptr);
-	theDBPtr->setPhoneNumber(myLine);
+	if(myLine == theDBPtr->getEmptyString())
+		theDBPtr->setPhoneNumber("");
+	else
+		theDBPtr->setPhoneNumber(myLine);
 }


### PR DESCRIPTION
I didn't really like most of the tooltips for the core objects, so I rewrote them to make them more useful.

I took special on the dynamite and the detonator box. There are now more useful tooltips when there is no phone number set.

Lastly, I updated some bad/incomplete tooltips of some special level objects (e.g. the “ZZZ” in Extreme Tux Racer had the balloon tooltip, 2 blue dominoes in Dial B For Boom had it as well).