### PR TITLE
Replace most RectObjects with standard objects

### DIFF
--- a/levels/draft/balloons-do-poof.xml
+++ b/levels/draft/balloons-do-poof.xml
@@ -19,12 +19,8 @@
         <scenesize width="3" height="2"/>
         <predefined>
             <object width="0.1" X="0.9" Y="1.25" height="1.5" type="Wall" angle="0"/>
-            <object width="3" X="1.5" Y="0.05" height="0.1" type="RectObject" angle="0">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
-            <object width="0.1" X="0.65" Y="0.05" height="0.1" type="RectObject" angle="0" ID="block">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="3" X="1.5" Y="0.05" height="0.1" type="Floor" angle="0"/>
+            <object width="0.1" X="0.65" Y="0.05" height="0.1" type="Floor" angle="0" ID="block"/>
             <object width="0.70" X="0.80" Y="0.30" height="0.60" type="Scenery">
                 <property key="ImageName">chickenwire-texture</property>
                 <property key="ZValue">10</property>
@@ -50,9 +46,7 @@
             </object>
             <object width="0.12" X="2.350375162511972" Y="0.2752126157283783" height="0.34" type="BowlingPin" ID="the-left-pin" angle="0"/>
             <object width="0.12" X="2.500249973691478" Y="0.2815407482722643" height="0.34" type="BowlingPin" ID="the-right-pin" angle="0"/>
-            <object width="1.6" X="1.75" Y="0.5499999999999999" height="0.11" type="RectObject" angle="0">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="1.6" X="1.75" Y="0.5499999999999999" height="0.11" type="Floor" angle="0"/>
             <object width="0.25" X="1.159779813680971" Y="0.8068034382721538" height="0.4" type="Cactus" angle="0"/>
             <object width="0.25" X="0.2143071428039244" Y="0.2983491595897771" height="0.4" type="Cactus" angle="0"/>
             <object width="0.3200000000000001" X="2.800000000000004" Y="0.4" height="0.6" type="Scenery" angle="0">

--- a/levels/draft/balloons-go-up.xml
+++ b/levels/draft/balloons-go-up.xml
@@ -32,9 +32,7 @@
             <object width="0.27" X="1.08660069216264" Y="0.2484542043386307" height="0.36" type="Balloon" angle="0"/>
             <object width="0.22" X="0.1890082300884956" Y="0.7" height="0.22" type="BowlingBall" angle="0"/>
             <object width="1.3" X="2.5" Y="1.05" height="0.14" type="SeesawSmall" angle="0" />
-            <object width="0.1" X="3.95" Y="0.6" height="1" type="RectObject" angle="0">
-                <property key="ImageName">oldbrick</property>
-            </object>
+            <object width="0.1" X="3.95" Y="0.6" height="1" type="Wall" angle="0"/>
             <object width="0.56" X="3.61" Y="0.27" height="0.34" type="LeftRamp" angle="0"/>
             <object width="0.21" X="1.9" Y="1.23" height="0.21" type="VolleyBall" angle="0"/>
             <object width="0.21" X="3.1" Y="1.23" height="0.21" type="VolleyBall" angle="0"/>

--- a/levels/draft/bouncing_balls.xml
+++ b/levels/draft/bouncing_balls.xml
@@ -21,10 +21,7 @@
             <object width="0.220" X="1.000" Y="2.500" height="0.220" type="SoccerBall" ID="soc" angle="0.000"/>
             <object width="0.220" X="1.300" Y="2.500" height="0.220" type="BowlingBall" ID="bow1" angle="0.000"/>
             <object width="0.220" X="1.600" Y="2.500" height="0.220" type="BowlingBall" ID="bow2" angle="0.000"/>
-            <object width="4.000" X="2.000" Y="0.050" height="0.100" type="RectObject" angle="0.000">
-                <property key="Bounciness">0.2</property>
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="4.000" X="2.000" Y="0.050" height="0.100" type="Floor" angle="0.000"/>
             <object width="0.220" X="1.500" Y="0.500" height="0.220" type="PostIt" angle="0.000">
                 <property key="page1">Welcome back!</property>
                 <property key="page2">No butterfly here...&lt;br>&lt;br>Don't worry - we haven't seen the last one yet</property>

--- a/levels/draft/bowling_pin_plays_soccer.xml
+++ b/levels/draft/bowling_pin_plays_soccer.xml
@@ -15,8 +15,7 @@
     <scene>
         <scenesize width="6" height="3.0"/>
         <predefined>
-            <object width="0.1" X="0.05" Y="1.45" height="2.7" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="0.1" X="0.05" Y="1.45" height="2.7" type="Floor">
                 <property key="Bounciness">0.05</property>
             </object>
             <object X="0.5" Y="2.4" type="BowlingBall"/>
@@ -24,18 +23,10 @@
                 <property key="ImageName">RightRamp</property>
             </object>
             <object X="3.95" Y="1.19" type="ColaMintBottle" angle="-1.57"/>
-            <object width="4.3" X="2.5" Y="1.05" type="Floor">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
-            <object width="1.2" X="4.05" Y="1.85" height="0.1" type="Floor">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
-            <object width="0.1" X="4.45" Y="1.65" height="0.3" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
-            <object width="2.4" X="1.3" Y="1.25" height="0.1" type="Floor">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="4.3" X="2.5" Y="1.05" type="Floor"/>
+            <object width="1.2" X="4.05" Y="1.85" height="0.1" type="Floor"/>
+            <object width="0.1" X="4.45" Y="1.65" height="0.3" type="Floor"/>
+            <object width="2.4" X="1.3" Y="1.25" height="0.1" type="Floor"/>
             <object width="3.7" X="1.95" Y="0.50" height="0.4" type="RightRamp" angle="0">
                 <property key="ImageName">RightRamp</property>
             </object>
@@ -56,9 +47,7 @@
             <object width="0.15" X="4.42" Y="0.45" height="0.7" type="RightRamp" angle="3.14">
                 <property key="ImageName">Empty</property>
             </object>
-            <object width="6.0" X="3.0" Y="0.05" type="Floor">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="6.0" X="3.0" Y="0.05" type="Floor"/>
             <object width="4.5" X="2.25" Y="0.55" height="1.0" type="Scenery">
                 <property key="ImageName">Empty</property>
             </object>

--- a/levels/draft/bridge-2.xml
+++ b/levels/draft/bridge-2.xml
@@ -23,12 +23,10 @@
     <scene>
         <scenesize width="5" height="3"/>
         <predefined>
-            <object width="0.9" X="0.7" Y="2.15" height="0.1" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="0.9" X="0.7" Y="2.15" height="0.1" type="Floor">
                 <property key="Bounciness">0.1</property>
             </object>
-            <object width="1.0" X="0.75" Y="1.1" height="2.0" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="1.0" X="0.75" Y="1.1" height="2.0" type="Floor">
                 <property key="Bounciness">0.0</property>
             </object>
             <object X="0.25" Y="2.7" type="Hammer">
@@ -41,27 +39,20 @@
                 <property key="page3">&lt;br> &lt;br> the Post-It Boy &lt;br> &lt;br> likes building bridges </property>
                 <property key="page4">&lt;br> &lt;br> ... and he likes crashing bridges even more!</property>
             </object>
-            <object width="4.4" X="2.2" Y="0.05" height="0.1" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="4.4" X="2.2" Y="0.05" height="0.1" type="Floor">
                 <property key="Bounciness">0.1</property>
             </object>
-            <object width="1.2" X="4.4" Y="2.35" height="0.1" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="1.2" X="4.4" Y="2.35" height="0.1" type="Floor">
                 <property key="Bounciness">0.1</property>
             </object>
-            <object width="0.6" X="4.1" Y="1.77" height="0.1" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="0.6" X="4.1" Y="1.77" height="0.1" type="Floor">
                 <property key="Bounciness">0.1</property>
             </object>
-            <object width="0.1" X="4.35" Y="0.90" height="1.70" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.1" X="4.35" Y="0.90" height="1.70" type="Floor"/>
             <object width="0.5" X="4.65" Y="0.45" height="0.9" type="Scenery">
                 <property key="ImageName">basket</property>
             </object>
-            <object width="0.1" X="4.95" Y="1.15" height="2.3" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.1" X="4.95" Y="1.15" height="2.3" type="Floor"/>
             <object X="4.1" Y="1.99" type="BowlingPin" ID="the Pin"/>
         </predefined>
     </scene>

--- a/levels/draft/bridge_gap.xml
+++ b/levels/draft/bridge_gap.xml
@@ -23,12 +23,10 @@
     <scene>
         <scenesize width="5" height="3"/>
         <predefined>
-            <object width="0.9" X="0.7" Y="2.15" height="0.1" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="0.9" X="0.7" Y="2.15" height="0.1" type="Floor">
                 <property key="Bounciness">0.1</property>
             </object>
-            <object width="1.0" X="0.75" Y="1.1" height="2.0" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="1.0" X="0.75" Y="1.1" height="2.0" type="Floor">
                 <property key="Bounciness">0.0</property>
             </object>
             <object X="0.25" Y="2.7" type="Hammer">
@@ -40,27 +38,20 @@
                 <property key="page2">I'm sure it needs help to cross over to the pin.</property>
                 <property key="page3">&lt;br> &lt;br> the Post-It Boy &lt;br> &lt;br> &lt;i>(insert joke about bridge here)&lt;/i> </property>
             </object>
-            <object width="4.4" X="2.2" Y="0.05" height="0.1" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="4.4" X="2.2" Y="0.05" height="0.1" type="Floor">
                 <property key="Bounciness">0.1</property>
             </object>
-            <object width="1.2" X="4.4" Y="2.35" height="0.1" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="1.2" X="4.4" Y="2.35" height="0.1" type="Floor">
                 <property key="Bounciness">0.1</property>
             </object>
-            <object width="0.6" X="4.1" Y="1.85" height="0.1" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="0.6" X="4.1" Y="1.85" height="0.1" type="Floor">
                 <property key="Bounciness">0.1</property>
             </object>
-            <object width="0.1" X="4.35" Y="0.94" height="1.78" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.1" X="4.35" Y="0.94" height="1.78" type="Floor"/>
             <object width="0.5" X="4.65" Y="0.45" height="0.9" type="Scenery">
                 <property key="ImageName">basket</property>
             </object>
-            <object width="0.1" X="4.95" Y="1.15" height="2.3" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.1" X="4.95" Y="1.15" height="2.3" type="Floor"/>
             <object X="4.1" Y="2.07" type="BowlingPin" ID="the Pin"/>
         </predefined>
     </scene>

--- a/levels/draft/butterfly-on-steroids.xml
+++ b/levels/draft/butterfly-on-steroids.xml
@@ -47,10 +47,9 @@
                 <property key="ImageName">brass-pin</property>
                 <property key="ZValue">4.5</property>
             </object>
-            <object height="0.100" ID="Bar" type="RectObject" X="1.250" width="1.000" Y="1.000" angle="1.570">
+            <object height="0.100" ID="Bar" type="BirchBar" X="1.250" width="1.000" Y="1.000" angle="1.570">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.0</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">5.0</property>
             </object>
             <object height="1.000" type="PivotPoint" X="1.250" width="1.000" Y="0.800" angle="0.000">
@@ -67,44 +66,37 @@
             <object height="0.200" ID="Flower" type="Scenery" X="4.200" width="0.200" Y="1.800" angle="0.000">
                 <property key="ImageName">Empty</property>
             </object>
-            <object height="0.950" type="RectObject" X="4.250" width="0.500" Y="0.525" angle="0.000">
+            <object height="0.950" type="Floor" X="4.250" width="0.500" Y="0.525" angle="0.000">
                 <property key="Bounciness">0.1</property>
                 <property key="Friction">1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object height="0.300" type="RectObject" X="4.050" width="0.100" Y="1.150" angle="0.000">
+            <object height="0.300" type="Floor" X="4.050" width="0.100" Y="1.150" angle="0.000">
                 <property key="Bounciness">0.1</property>
                 <property key="Friction">0.8</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object height="2.300" type="RectObject" X="4.550" width="0.100" Y="1.150" angle="0.000">
+            <object height="2.300" type="Floor" X="4.550" width="0.100" Y="1.150" angle="0.000">
                 <property key="Friction">0.8</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object height="0.500" type="ColaMintBottle" X="1.770" width="0.166" Y="0.720" angle="1.570"/>
-            <object height="0.100" type="RectObject" X="2.300" width="1.200" Y="0.600" angle="0.000">
+            <object height="0.100" type="Floor" X="2.300" width="1.200" Y="0.600" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.0</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object height="0.100" type="RectObject" X="2.800" width="1.700" Y="1.000" angle="0.000">
+            <object height="0.100" type="Floor" X="2.800" width="1.700" Y="1.000" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.0</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object height="0.100" type="RectObject" X="3.650" width="0.200" Y="1.000" angle="0.000">
+            <object height="0.100" type="Floor" X="3.650" width="0.200" Y="1.000" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.8</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object height="0.100" ID="BrassPin2" type="RectObject" X="3.050" width="0.100" Y="0.450" angle="0.000">
                 <property key="ImageName">brass-pin</property>
                 <property key="ZValue">4.5</property>
             </object>
-            <object height="0.100" ID="Bar2" type="RectObject" X="3.050" width="0.700" Y="0.500" angle="1.570">
+            <object height="0.100" ID="Bar2" type="BirchBar" X="3.050" width="0.700" Y="0.500" angle="1.570">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.0</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">15.0</property>
             </object>
             <object height="1.000" type="PivotPoint" X="3.050" width="1.000" Y="0.450" angle="0.000">
@@ -115,20 +107,18 @@
                 <property key="ImageName">brass-pin</property>
                 <property key="ZValue">4.5</property>
             </object>
-            <object height="0.100" ID="Bar3" type="RectObject" X="1.600" width="2.500" Y="2.150" angle="0.000">
+            <object height="0.100" ID="Bar3" type="BirchBar" X="1.600" width="2.500" Y="2.150" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.5</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">1.0</property>
             </object>
             <object height="1.000" type="PivotPoint" X="2.800" width="1.000" Y="2.150" angle="0.000">
                 <property key="object1">Bar3</property>
                 <property key="object2">BrassPin3</property>
             </object>
-            <object height="0.100" ID="Bar3a" type="RectObject" X="0.400" width="0.100" Y="2.250" angle="0.000">
+            <object height="0.100" ID="Bar3a" type="BirchBar" X="0.400" width="0.100" Y="2.250" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.5</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">1.0</property>
             </object>
             <object height="1.000" type="PivotPoint" X="0.400" width="1.000" Y="2.200" angle="0.000">
@@ -140,21 +130,18 @@
                 <property key="Mass">   0.7</property>
                 <property key="Thrust">15.0</property>
             </object>
-            <object height="1.820" type="RectObject" X="0.500" width="0.200" Y="1.010" angle="0.000">
+            <object height="1.820" type="Floor" X="0.500" width="0.200" Y="1.010" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.0</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object height="0.100" type="RectObject" X="0.540" width="0.100" Y="1.910" angle="0.000">
+            <object height="0.100" type="Floor" X="0.540" width="0.100" Y="1.910" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.4</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object height="0.250" type="Skyhook" X="0.350" width="0.180" Y="2.480" angle="0.000"/>
-            <object height="1.500" type="RectObject" X="0.850" width="0.100" Y="1.200" angle="0.000">
+            <object height="1.500" type="Floor" X="0.850" width="0.100" Y="1.200" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.4</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object height="0.800" type="RectObject" X="3.700" width="0.150" Y="1.450" angle="0.000">
                 <property key="Bounciness">0.2</property>

--- a/levels/draft/cola-powered-bike.v2.xml
+++ b/levels/draft/cola-powered-bike.v2.xml
@@ -25,10 +25,9 @@
                 <property key="ImageName">brass-pin</property>
                 <property key="ZValue">4.5</property>
             </object>
-            <object width="2.200" X="1.400" Y="1.400" height="0.150" type="RectObject" ID="Bar" angle="0.000">
+            <object width="2.200" X="1.400" Y="1.400" height="0.150" type="BirchBar" ID="Bar" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.7</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">8</property>
             </object>
             <object width="1.000" X="1.400" Y="1.400" height="1.000" type="PivotPoint" angle="0.000">
@@ -109,10 +108,9 @@
                 <property key="object1">BikeBody</property>
                 <property key="object2">RightWheel</property>
             </object>
-            <object width="1.220" X="3.200" Y="0.300" height="0.100" type="RectObject" ID="Lever" angle="0.000">
+            <object width="1.220" X="3.200" Y="0.300" height="0.100" type="BirchBar" ID="Lever" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.4</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">3.0</property>
             </object>
             <object width="0.100" X="3.300" Y="0.300" height="0.100" type="RectObject" ID="Fulcrum" angle="0.000">
@@ -127,9 +125,8 @@
                 <property key="Friction">0.4</property>
             </object>
             <object width="0.120" X="3.179" Y="1.500" height="0.340" type="BowlingPin" ID="BowlingPin" angle="0.000"/>
-            <object width="0.100" X="2.750" Y="1.424" height="0.747" type="RectObject" angle="0.000">
+            <object width="0.100" X="2.750" Y="1.424" height="0.747" type="Floor" angle="0.000">
                 <property key="Friction">0.4</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.496" X="3.021" Y="1.280" height="0.100" type="Floor" angle="0.000">
                 <property key="Friction">0.4</property>

--- a/levels/draft/contraption1.xml
+++ b/levels/draft/contraption1.xml
@@ -18,12 +18,10 @@
     <scene>
         <scenesize width="4.7" height="3.5"/>
         <predefined>
-            <object width="0.1" X="0.05" Y="1.80" height="3.4" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="0.1" X="0.05" Y="1.80" height="3.4" type="Floor">
                 <property key="Bounciness">0.05</property>
             </object>
             <object width="4.7" X="2.35" Y="0.05" height="0.10" type="Floor">
-                <property key="ImageName">used_wood_bar</property>
                 <property key="Friction">0.6</property>
             </object>
             <object X="3.5" Y="1.0" type="PostIt">
@@ -73,18 +71,13 @@
             <object X="4.3" Y="0.36" type="Balloon"/>
             <!-- ===================== 'outer slakkenhuis' ================= -->
             <object width="3.7" X="2.45" Y="0.61" height="0.10" type="Floor">
-                <property key="ImageName">used_wood_bar</property>
                 <property key="Friction">0.4</property>
             </object>
-            <object width="0.1" X="4.65" Y="1.30" height="2.4" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="0.1" X="4.65" Y="1.30" height="2.4" type="Floor">
                 <property key="Friction">0.1</property>
             </object>
-            <object width="0.1" X="2.05" Y="1.50" height="1.8" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.1" X="2.05" Y="1.50" height="1.8" type="Floor"/>
             <object width="2.6" X="3.3" Y="2.45" height="0.10" type="Floor">
-                <property key="ImageName">used_wood_bar</property>
                 <property key="Friction">0.4</property>
             </object>
             <object width="0.3" X="4.45" Y="2.1" height="0.6" type="RightFixedWedge" angle="3.14">
@@ -95,18 +88,14 @@
             <object width="0.8" X="2.17" Y="1.96" height="0.15" type="BedOfNails" angle="-1.57"/>
             <!-- ===================== 'inner slakkenhuis' ================= -->
             <object X="3.7" Y="0.84" type="BowlingPin" ID="BowlingPin2"/>
-            <object width="0.1" X="4.15" Y="1.20" height="1.2" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.1" X="4.15" Y="1.20" height="1.2" type="Floor"/>
             <object width="1.6" X="3.3" Y="1.8" height="0.10" type="Floor" angle="0.05">
                 <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.2" X="4.10" Y="1.85" height="0.10" type="Floor">
                 <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.1" X="2.55" Y="1.45" height="0.7" type="RectObject">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.1" X="2.55" Y="1.45" height="0.7" type="Floor"/>
             <object X="4.20" Y="2.00" type="VolleyBall"/>
             <object X="1.509" Y="1.612" width="1.000" angle="0.000" type="Floor" height="0.100"/>
         </predefined>

--- a/levels/draft/contraption2.xml
+++ b/levels/draft/contraption2.xml
@@ -26,9 +26,8 @@
     <scene>
         <scenesize width="4.6" height="3.7"/>
         <predefined>
-            <object width="0.1" X="0.05" Y="1.9" height="3.6" type="RectObject" angle="0">
+            <object width="0.1" X="0.05" Y="1.9" height="3.6" type="Floor" angle="0">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="4.6" X="2.3" Y="0.05" height="0.1" type="Floor" angle="0">
                 <property key="Friction">0.6</property>
@@ -49,10 +48,9 @@
                 <property key="Radius">0.05</property>
                 <property key="ZValue">4.5</property>
             </object>
-            <object width="1.3" X="1" Y="2.7" height="0.1" type="RectObject" ID="Bar" angle="-0.2">
+            <object width="1.3" X="1" Y="2.7" height="0.1" type="BirchBar" ID="Bar" angle="-0.2">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.7</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">4</property>
             </object>
             <object width="1" X="1" Y="2.7" height="1" type="PivotPoint" angle="0">
@@ -75,20 +73,18 @@
                 <property key="Radius">0.05</property>
                 <property key="ZValue">4.5</property>
             </object>
-            <object width="1.3" X="1" Y="1.25" height="0.1" type="RectObject" ID="Bar2" angle="0.15">
+            <object width="1.3" X="1" Y="1.25" height="0.1" type="BirchBar" ID="Bar2" angle="0.15">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.7</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">4</property>
             </object>
             <object width="1" X="1" Y="1.25" height="1" type="PivotPoint" angle="0">
                 <property key="object1">Bar2</property>
                 <property key="object2">BrassPin2</property>
             </object>
-            <object width="0.3" X="0.39" Y="1.26" height="0.1" type="RectObject" ID="Bar2x" angle="1.72">
+            <object width="0.3" X="0.39" Y="1.26" height="0.1" type="BirchBar" ID="Bar2x" angle="1.72">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.7</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">0.1</property>
             </object>
             <object width="1" X="0.35" Y="1.2" height="1" type="PivotPoint" angle="0">
@@ -108,10 +104,9 @@
                 <property key="Radius">0.05</property>
                 <property key="ZValue">4.5</property>
             </object>
-            <object width="1.4" X="3.05" Y="1.2" height="0.1" type="RectObject" ID="Bar3" angle="0.2">
+            <object width="1.4" X="3.05" Y="1.2" height="0.1" type="BirchBar" ID="Bar3" angle="0.2">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.1</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">6</property>
             </object>
             <object width="0.1" X="3.1" Y="1.18" height="0.1" type="RectObject" ID="BrassPin3" angle="0">
@@ -122,10 +117,9 @@
                 <property key="object1">Bar3</property>
                 <property key="object2">BrassPin3</property>
             </object>
-            <object width="0.3" X="3.77" Y="1.45" height="0.1" type="RectObject" ID="Bar3x" angle="1.72">
+            <object width="0.3" X="3.77" Y="1.45" height="0.1" type="BirchBar" ID="Bar3x" angle="1.72">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.7</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">0.1</property>
             </object>
             <object width="0.04" X="3.70" Y="1.35" height="0.1" type="Glue" angle="0">
@@ -139,15 +133,13 @@
             </object>
             <object width="0.22" X="2.25" Y="1.04" height="0.22" type="BowlingBall" angle="0"/>
             <object width="0.3" X="2.13" Y="0.96" height="0.15" type="RightRamp" angle="0"/>
-            <object width="1" X="1.7" Y="0.7" height="0.1" type="RectObject" angle="0">
+            <object width="1" X="1.7" Y="0.7" height="0.1" type="Floor" angle="0">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="1.4" X="3.5" Y="0.6" height="0.1" type="RectObject" angle="0">
+            <object width="1.4" X="3.5" Y="0.6" height="0.1" type="Floor" angle="0">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.7" X="0.42" Y="0.13" height="0.16" type="Floor" angle="0.17">
                 <property key="Friction">0.8</property>
@@ -168,10 +160,9 @@
                 <property key="ImageName">DominoGreen</property>
                 <property key="Mass">3.5</property>
             </object>
-            <object width="0.1" X="2.9" Y="0.15" height="0.1" type="RectObject" angle="0.01">
+            <object width="0.1" X="2.9" Y="0.15" height="0.1" type="Floor" angle="0.01">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.1" X="2.35" Y="0.3" height="0.4" type="DominoRed" angle="0">
                 <property key="ImageName">DominoRed</property>
@@ -198,28 +189,24 @@
                 <property key="Mass">2.5</property>
             </object>
             <object width="0.12" X="4.2" Y="3.43" height="0.34" type="BowlingPin" ID="BowlingPin2" angle="0"/>
-            <object width="0.5600000000000001" X="3.87" Y="2.8" height="0.1" type="RectObject" angle="0">
+            <object width="0.5600000000000001" X="3.87" Y="2.8" height="0.1" type="Floor" angle="0">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.1" X="3.55" Y="3.05" height="0.6" type="RectObject" angle="0">
+            <object width="0.1" X="3.55" Y="3.05" height="0.6" type="Floor" angle="0">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.6" X="3.9" Y="3.05" height="0.4" type="Scenery" angle="0">
                 <property key="ImageName">basket</property>
             </object>
-            <object width="0.1" X="4.2" Y="1.9" height="2.7" type="RectObject" angle="0">
+            <object width="0.1" X="4.2" Y="1.9" height="2.7" type="Floor" angle="0">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.166" X="4.38" Y="0.35" height="0.501" type="ColaMintBottle" angle="3.14">
                 <property key="Thrust">5</property>
             </object>
             <object width="0.4" X="4.42" Y="3.5" height="0.2" type="LeftRamp" angle="1.57"/>
-            <object width="0.1" X="4.55" Y="1.9" height="3.6" type="RectObject" angle="0">
+            <object width="0.1" X="4.55" Y="1.9" height="3.6" type="Floor" angle="0">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="3.000" X="1.700" Y="3.500" height="0.803" type="Scenery" angle="0.000">
                 <property key="ImageName">clouds</property>

--- a/levels/draft/domino_day.xml
+++ b/levels/draft/domino_day.xml
@@ -32,15 +32,13 @@
     <scene>
         <scenesize width="6" height="3"/>
         <predefined>
-            <object width="6.000" X="3.000" Y="-0.040" height="0.100" type="RectObject" angle="0.000">
+            <object width="6.000" X="3.000" Y="-0.040" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="1.000" X="0.500" Y="2.750" height="0.400" type="RightRamp" angle="0.000"/>
             <object width="0.220" X="0.780" Y="2.880" height="0.220" type="BowlingBall" angle="0.000"/>
-            <object width="4.000" X="3.000" Y="2.350" height="0.100" type="RectObject" angle="0.000">
+            <object width="4.000" X="3.000" Y="2.350" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.100" X="1.100" Y="2.650" height="0.500" type="DominoRed" angle="0.000">
                 <property key="ImageName">DominoRed</property>
@@ -72,18 +70,15 @@
             <object width="0.100" X="4.700" Y="2.650" height="0.500" type="DominoRed" angle="0.000">
                 <property key="ImageName">DominoRed</property>
             </object>
-            <object width="4.200" X="3.300" Y="1.600" height="0.100" type="RectObject" angle="0.000">
+            <object width="4.200" X="3.300" Y="1.600" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.0</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.300" X="5.800" Y="2.050" height="1.000" type="RectObject" angle="0.000">
+            <object width="0.300" X="5.800" Y="2.050" height="1.000" type="Floor" angle="0.000">
                 <property key="Bounciness">0.0</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.220" X="5.100" Y="1.970" height="0.220" type="BowlingBall" angle="0.000"/>
-            <object width="0.600" X="5.350" Y="1.700" height="0.300" type="RectObject" angle="0.000">
+            <object width="0.600" X="5.350" Y="1.700" height="0.300" type="Floor" angle="0.000">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.100" X="4.900" Y="1.900" height="0.500" type="DominoGreen" angle="0.000">
                 <property key="ImageName">DominoGreen</property>
@@ -117,18 +112,15 @@
                 <property key="ImageName">DominoGreen</property>
                 <property key="Mass">0.5</property>
             </object>
-            <object width="5.000" X="2.500" Y="0.800" height="0.100" type="RectObject" angle="0.000">
+            <object width="5.000" X="2.500" Y="0.800" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.300" X="1.050" Y="1.500" height="0.100" type="RectObject" angle="0.000">
+            <object width="0.300" X="1.050" Y="1.500" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.0</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.166" X="1.050" Y="1.800" height="0.500" type="ColaMintBottle" angle="0.000"/>
-            <object width="0.100" X="1.100" Y="0.930" height="0.160" type="RectObject" angle="0.000">
+            <object width="0.100" X="1.100" Y="0.930" height="0.160" type="Floor" angle="0.000">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.220" X="0.200" Y="1.400" height="0.220" type="PostIt" angle="0.000">
                 <property key="page1">It falls down, blows ...&lt;br>&lt;br>and doesn't do anything useful</property>
@@ -168,14 +160,10 @@
                 <property key="ImageName">DominoGreen</property>
             </object>
             <object width="1.200" X="5.400" Y="0.650" height="0.700" type="LeftRamp" angle="0.000"/>
-            <object width="0.350" X="0.760" Y="0.205" height="0.410" type="RectObject" angle="0.000">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.350" X="0.760" Y="0.205" height="0.410" type="Floor" angle="0.000"/>
             <object width="0.220" X="0.900" Y="0.530" height="0.220" type="BowlingBall" angle="0.000"/>
             <object width="0.120" X="0.500" Y="0.320" height="0.340" type="BowlingPin" ID="Left-Bottom-Pin" angle="0.000"/>
-            <object width="0.200" X="0.500" Y="0.060" height="0.120" type="RectObject" angle="0.000">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.200" X="0.500" Y="0.060" height="0.120" type="Floor" angle="0.000"/>
             <object width="1.000" X="5.460" Y="1.200" height="0.800" type="Scenery" angle="0.000">
                 <property key="ImageName">chickenwire-texture</property>
             </object>

--- a/levels/draft/find-the-message.v2.xml
+++ b/levels/draft/find-the-message.v2.xml
@@ -28,9 +28,8 @@
         <scenesize width="6" height="4"/>
         <predefined>
             <object width="5.528" X="3.241" Y="0.050" height="0.100" type="Floor" angle="0.000"/>
-            <object width="0.100" X="0.050" Y="1.299" height="2.586" type="RectObject" angle="0.000">
+            <object width="0.100" X="0.050" Y="1.299" height="2.586" type="Floor" angle="0.000">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="2.000" X="2.100" Y="1.750" height="1.400" type="Scenery" angle="0.000">
                 <property key="ImageName">thank-you-stone</property>

--- a/levels/draft/geyser.xml
+++ b/levels/draft/geyser.xml
@@ -43,35 +43,28 @@
             </object>
             <object width="0.210" X="1.500" Y="3.000" height="0.210" type="VolleyBall" angle="0.000"/>
             <object width="0.220" X="0.200" Y="1.000" height="0.220" type="BowlingBall" angle="0.000"/>
-            <object width="1.600" X="1.250" Y="0.773" height="0.100" type="RectObject" angle="-0.250">
+            <object width="1.600" X="1.250" Y="0.773" height="0.100" type="Floor" angle="-0.250">
                 <property key="Bounciness">0.05</property>
                 <property key="Friction">0.5</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.600" X="2.310" Y="0.573" height="0.100" type="RectObject" angle="0.000">
+            <object width="0.600" X="2.310" Y="0.573" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.00</property>
                 <property key="Friction">0.5</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.100" X="2.520" Y="0.450" height="0.200" type="RectObject" angle="0.000">
+            <object width="0.100" X="2.520" Y="0.450" height="0.200" type="Floor" angle="0.000">
                 <property key="Bounciness">0.00</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.119" X="2.789" Y="0.577" height="0.100" type="RectObject" angle="0.000">
+            <object width="0.119" X="2.789" Y="0.577" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.5</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.166" X="2.660" Y="0.350" height="0.500" type="ColaMintBottle" angle="0.000">
                 <property key="Thrust">7</property>
             </object>
-            <object width="0.100" X="2.800" Y="0.349" height="0.500" type="RectObject" angle="0.000">
+            <object width="0.100" X="2.800" Y="0.349" height="0.500" type="Floor" angle="0.000">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.100" X="2.900" Y="0.150" height="0.100" type="RectObject" angle="0.000">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.100" X="2.900" Y="0.150" height="0.100" type="Floor" angle="0.000"/>
             <object width="1.000" X="2.700" Y="1.100" height="0.100" type="Scenery" angle="1.570">
                 <property key="ImageName">carpenters-rule</property>
                 <property key="ZValue">0.5</property>
@@ -81,18 +74,15 @@
                 <property key="ZValue">0.6</property>
             </object>
             <object width="0.120" X="3.500" Y="0.270" height="0.340" type="BowlingPin" ID="BowlingPin" angle="0.000"/>
-            <object width="1.200" X="4.400" Y="0.320" height="0.100" type="RectObject" angle="0.450">
+            <object width="1.200" X="4.400" Y="0.320" height="0.100" type="Floor" angle="0.450">
                 <property key="Bounciness">0.05</property>
                 <property key="Friction">0.5</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.100" X="4.950" Y="0.650" height="1.100" type="RectObject" angle="0.000">
+            <object width="0.100" X="4.950" Y="0.650" height="1.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="2.000" X="3.900" Y="1.150" height="0.100" type="RectObject" angle="0.000">
+            <object width="2.000" X="3.900" Y="1.150" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.200" X="3.300" Y="0.650" height="0.230" type="Skyhook" angle="0.000">
                 <property key="Bounciness">0.05</property>

--- a/levels/draft/imperfectbalance.xml
+++ b/levels/draft/imperfectbalance.xml
@@ -37,15 +37,13 @@
             <object width="0.2" X="1.47" Y="1.9" height="0.23" type="Skyhook" ID="Skyhook" angle="0">
                 <property key="ZValue">0.5</property>
             </object>
-            <object width="2.6" X="1.59" Y="1.95" height="0.1" type="RectObject" angle="0">
+            <object width="2.6" X="1.59" Y="1.95" height="0.1" type="IBeam" angle="0">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.5</property>
-                <property key="ImageName">i-beam</property>
                 <property key="Mass">100</property>
             </object>
-            <object width="3.2" X="2.1" Y="0.5" height="0.1" type="RectObject" angle="0">
+            <object width="3.2" X="2.1" Y="0.5" height="0.1" type="Floor" angle="0">
                 <property key="Bounciness">0.0</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.15" X="3.9" Y="0.3" height="0.4" type="RectObject" angle="0">
                 <property key="Bounciness">0.6</property>
@@ -60,10 +58,8 @@
             <object width="0.15" X="2.5" Y="0.9399999999999999" height="0.2280269058295964" type="Butterfly" ID="Butterfly" angle="0">
                 <property key="Object">Flower</property>
             </object>
-            <object width="0.5" X="4.25" Y="0.48" height="0.1" type="RectObject" angle="0">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
-            <object width="0.5" X="4.25" Y="0.58" height="0.1" type="RectObject" angle="0">
+            <object width="0.5" X="4.25" Y="0.48" height="0.1" type="Floor" angle="0"/>
+            <object width="0.5" X="4.25" Y="0.58" height="0.1" type="Floor" angle="0">
                 <property key="ImageName">White-to-green</property>
             </object>
             <object width="0.2" X="4.3" Y="0.775" height="0.45" type="RectObject" angle="0">

--- a/levels/draft/jumping_around-2.xml
+++ b/levels/draft/jumping_around-2.xml
@@ -19,13 +19,10 @@
     <scene>
         <scenesize width="5" height="3"/>
         <predefined>
-            <object width="0.900" X="1.100" Y="2.400" height="0.100" type="RectObject" angle="0.000">
+            <object width="0.900" X="1.100" Y="2.400" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.100" X="1.050" Y="1.200" height="2.300" type="RectObject" angle="0.000">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.100" X="1.050" Y="1.200" height="2.300" type="Floor" angle="0.000"/>
             <object width="0.600" X="0.300" Y="2.660" height="0.400" type="RightRamp" angle="0.000"/>
             <object width="0.220" X="2.000" Y="0.500" height="0.220" type="PostIt" angle="0.000">
                 <property key="page1">Soccer Balls are a little bouncy, but sometimes "a little" is not enough.</property>
@@ -34,27 +31,20 @@
                 <property key="page4">Notice a new trick: rotate.</property>
                 <property key="page5">the Post-It Boy</property>
             </object>
-            <object width="4.400" X="2.200" Y="0.050" height="0.100" type="RectObject" angle="0.000">
+            <object width="4.400" X="2.200" Y="0.050" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="1.200" X="4.387" Y="1.828" height="0.100" type="RectObject" angle="0.000">
+            <object width="1.200" X="4.387" Y="1.828" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.600" X="4.091" Y="0.987" height="0.100" type="RectObject" angle="0.000">
+            <object width="0.600" X="4.091" Y="0.987" height="0.100" type="Floor" angle="0.000">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.100" X="4.350" Y="0.541" height="0.981" type="RectObject" angle="0.000">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.100" X="4.350" Y="0.541" height="0.981" type="Floor" angle="0.000"/>
             <object width="0.500" X="4.650" Y="0.450" height="0.900" type="Scenery" angle="0.000">
                 <property key="ImageName">basket</property>
             </object>
-            <object width="0.100" X="4.950" Y="0.934" height="1.868" type="RectObject" angle="0.000">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.100" X="4.950" Y="0.934" height="1.868" type="Floor" angle="0.000"/>
             <object width="0.120" X="4.354" Y="1.220" height="0.340" type="BowlingPin" ID="the Pin" angle="0.000"/>
             <object width="0.220" X="0.221" Y="2.868" height="0.220" type="SoccerBall" angle="0.000">
                 <property key="Mass">1</property>

--- a/levels/draft/jumping_around.xml
+++ b/levels/draft/jumping_around.xml
@@ -46,12 +46,8 @@
             <object Y="0.85" width="0.6" height="0.1" X="4.1" angle="0" type="Floor">
                 <property key="Bounciness">0.1</property>
             </object>
-            <object Y="0.44" width="0.1" height="0.78" X="4.35" angle="0" type="Floor">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
-            <object Y="0.653344" width="0.1" height="1.3" X="5.10383" angle="0" type="Floor">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object Y="0.44" width="0.1" height="0.78" X="4.35" angle="0" type="Floor"/>
+            <object Y="0.653344" width="0.1" height="1.3" X="5.10383" angle="0" type="Floor"/>
             <object Y="0.575" width="0.6" height="0.95" X="4.7" angle="0" type="ToyChest">
                 <property key="ZValue">12</property>
             </object>

--- a/levels/draft/spare-the-balloon.xml
+++ b/levels/draft/spare-the-balloon.xml
@@ -27,12 +27,10 @@
             <object width="0.270" X="0.810" Y="0.390" height="0.360" type="Balloon" ID="theBalloon" angle="0.000"/>
             <object width="0.800" X="1.006" Y="1.821" height="0.150" type="BedOfNails" angle="-3.140"/>
             <object width="0.100" X="0.552" Y="1.490" height="0.911" type="Floor" angle="0.000"/>
-            <object width="0.600" X="0.300" Y="0.500" height="0.800" type="RectObject" angle="0.000">
+            <object width="0.600" X="0.300" Y="0.500" height="0.800" type="Floor" angle="0.000">
                 <property key="ImageName">big_used_wood_bar</property>
             </object>
-            <object width="0.100" X="0.050" Y="1.409" height="1.022" type="RectObject" angle="0.000">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.100" X="0.050" Y="1.409" height="1.022" type="Floor" angle="0.000"/>
             <object width="0.250" X="1.216" Y="0.201" height="0.400" type="Cactus" angle="0.000">
                 <property key="Mass">0</property>
             </object>

--- a/levels/draft/steam-machine.xml
+++ b/levels/draft/steam-machine.xml
@@ -42,8 +42,7 @@
                 <property key="ImageName">used_wood_bar</property>
                 <property key="Friction">0.0</property>
             </object>
-            <object width="0.8" X="1.2" Y="1.35" height="0.10" type="RectObject" ID="Lever">
-                <property key="ImageName">birch_bar</property>
+            <object width="0.8" X="1.2" Y="1.35" height="0.10" type="BirchBar" ID="Lever">
                 <property key="Friction">0.0</property>
                 <property key="Mass">3.0</property>
             </object>
@@ -65,8 +64,7 @@
                 <property key="ImageName">used_wood_bar</property>
                 <property key="Friction">0.4</property>
             </object>
-            <object width="0.4" X="1.2" Y="0.65" height="0.10" type="RectObject" ID="FreeThingie">
-                <property key="ImageName">birch_bar</property>
+            <object width="0.4" X="1.2" Y="0.65" height="0.10" type="BirchBar" ID="FreeThingie">
                 <property key="Friction">0.0</property>
                 <property key="Mass">3.0</property>
             </object>

--- a/levels/draft/topple-the-other-way.xml
+++ b/levels/draft/topple-the-other-way.xml
@@ -40,10 +40,9 @@
                 <property key="ImageName">brass-pin</property>
                 <property key="ZValue">4.5</property>
             </object>
-            <object width="2.800" X="2.200" Y="2.300" height="0.150" type="RectObject" ID="Bar" angle="0.000">
+            <object width="2.800" X="2.200" Y="2.300" height="0.150" type="BirchBar" ID="Bar" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.7</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">8</property>
             </object>
             <object width="1.000" X="2.200" Y="2.300" height="1.000" type="PivotPoint" angle="0.000">

--- a/levels/draft/turn-it-around.xml
+++ b/levels/draft/turn-it-around.xml
@@ -36,18 +36,16 @@
             <object width="5.000" X="2.700" Y="0.30" height="1.500" type="Scenery" angle="0.000">
                 <property key="ImageName">the-sun</property>
             </object>
-            <object width="1.200" X="0.780" Y="0.320" height="0.100" type="RectObject" angle="-0.450">
+            <object width="1.200" X="0.780" Y="0.320" height="0.100" type="Floor" angle="-0.450">
                 <property key="Bounciness">0.05</property>
                 <property key="Friction">0.5</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.940" X="1.770" Y="0.050" height="0.100" type="Floor" angle="0.000">
                 <property key="Friction">0.4</property>
             </object>
-            <object width="1.200" X="3.620" Y="0.320" height="0.100" type="RectObject" angle="0.450">
+            <object width="1.200" X="3.620" Y="0.320" height="0.100" type="Floor" angle="0.450">
                 <property key="Bounciness">0.05</property>
                 <property key="Friction">0.5</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.220" X="2.200" Y="2.600" height="0.220" type="PostIt" angle="0.000">
                 <property key="page1">This is not a stable equilibrium, any excitation will make it move.</property>
@@ -58,10 +56,9 @@
                 <property key="ImageName">brass-pin</property>
                 <property key="ZValue">4.5</property>
             </object>
-            <object width="2.800" X="2.200" Y="1.900" height="0.150" type="RectObject" ID="Bar" angle="0.000">
+            <object width="2.800" X="2.200" Y="1.900" height="0.150" type="BirchBar" ID="Bar" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.7</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">8</property>
             </object>
             <object width="1.000" X="2.200" Y="1.900" height="1.000" type="PivotPoint" angle="0.000">

--- a/levels/draft/zoingandboom.xml
+++ b/levels/draft/zoingandboom.xml
@@ -133,13 +133,10 @@
             <object X="3.458" Y="3.681" width="0.45" angle="0" type="Hammer" height="0.18">
                 <property key="Mass">15.0</property>
             </object>
-            <object X="3.285" Y="1.395" width="0.756" angle="0" type="RectObject" height="0.402">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object X="3.285" Y="1.395" width="0.756" angle="0" type="Floor" height="0.402"/>
             <object X="4.071" Y="0.94" width="0.822" angle="0" type="SeesawSmall" height="0.14" />
             <object X="2.963" Y="2.179" width="1.206" angle="1.57" type="Floor" height="0.1"/>
-            <object X="4.87" Y="1.15" width="1" angle="0" type="RectObject" height="0.14">
-                <property key="ImageName">birch_bar</property>
+            <object X="4.87" Y="1.15" width="1" angle="0" type="BirchBar" height="0.14">
                 <property key="Mass">3</property>
                 <property key="PivotPoint">(0,0)</property>
             </object>

--- a/levels/elce09/002.xml
+++ b/levels/elce09/002.xml
@@ -45,16 +45,14 @@
                 <property key="Bounciness">0.75</property>
                 <property key="ImageName">VolleyBall</property>
             </object>
-            <object width="0.9" X="0.4" Y="0.85" height="0.1" type="RectObject" angle="-0.45">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="0.9" X="0.4" Y="0.85" height="0.1" type="Floor" angle="-0.45">
                 <property key="ZValue">0.6</property>
                 <property key="Bounciness">0.05</property>
             </object>
             <object width="0.2" X="0.1" Y="0.5" height="1.0" type="Wall">
                 <property key="ZValue">0.5</property>
             </object>
-            <object width="0.4" X="0.25" Y="0.73" height="0.1" type="RectObject" angle="0.7">
-                <property key="ImageName">used_wood_bar</property>
+            <object width="0.4" X="0.25" Y="0.73" height="0.1" type="Floor" angle="0.7">
                 <property key="ZValue">0.4</property>
             </object>
             <object X="1.1" Y="1.0" type="PostIt">

--- a/levels/elce09/003.xml
+++ b/levels/elce09/003.xml
@@ -37,9 +37,7 @@
             </object>
             <object width="0.300" X="6.400" Y="0.115" height="0.230" type="Floor" angle="0.000"/>
             <object width="1.032" X="5.016" Y="0.115" height="0.230" type="Floor" angle="0.000"/>
-            <object width="0.100" X="6.850" Y="0.320" height="0.640" type="RectObject" angle="0.000">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.100" X="6.850" Y="0.320" height="0.640" type="Floor" angle="0.000"/>
             <object width="0.220" X="6.300" Y="0.800" height="0.220" type="PostIt" angle="0.000">
                 <property key="page1">No butterflies here!&lt;br>&lt;br></property>
                 <property key="page2">Topple the bowling pin below.</property>

--- a/levels/elce09/004.xml
+++ b/levels/elce09/004.xml
@@ -15,10 +15,9 @@
     <scene>
         <scenesize width="4.5" height="3"/>
         <predefined>
-            <object width="2.200" X="1.400" Y="0.300" height="0.100" type="RectObject" ID="Bar" angle="0.000">
+            <object width="2.200" X="1.400" Y="0.300" height="0.100" type="BirchBar" ID="Bar" angle="0.000">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">2.0</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">6.0</property>
                 <property key="PivotPoint">(0.3,-0.05)</property>
             </object>
@@ -37,11 +36,7 @@
             </object>
             <object width="0.120" X="4.100" Y="0.270" height="0.340" type="BowlingPin" ID="Pin2" angle="0.000"/>
             <object width="0.120" X="3.900" Y="0.270" height="0.340" type="BowlingPin" ID="Pin3" angle="0.000"/>
-            <object width="0.255" X="2.123" Y="0.660" height="0.327" type="RectObject" angle="0.000">
-                <property key="Bounciness">0.0</property>
-                <property key="Friction">2.0</property>
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object width="0.255" X="2.123" Y="0.660" height="0.327" type="Floor" angle="0.000"/>
             <object width="1.400" X="3.800" Y="0.650" height="0.200" type="LeftRamp" angle="0.000"/>
             <object width="1.400" X="0.700" Y="2.950" height="0.100" type="RectObject" angle="0.000">
                 <property key="Bounciness">0.0</property>
@@ -59,7 +54,7 @@
             <object width="0.500" X="2.570" Y="0.700" height="0.100" type="Floor" angle="1.570"/>
             <object width="1.972" X="3.506" Y="0.500" height="0.100" type="Floor" angle="0.000"/>
             <object width="0.250" X="2.750" Y="0.750" height="0.400" type="Cactus" angle="0.000"/>
-            <object width="1.056" X="1.661" Y="0.619" height="0.244" type="RectObject" angle="0.000">
+            <object width="1.056" X="1.661" Y="0.619" height="0.244" type="Floor" angle="0.000">
                 <property key="ImageName">big_used_wood_bar</property>
             </object>
         </predefined>

--- a/levels/elce09/007.xml
+++ b/levels/elce09/007.xml
@@ -78,13 +78,11 @@
                 <property key="Mass">1</property>
             </object>
             <object width="0.6" X="7.55" Y="1.94" height="3.65" type="Wall"/>
-            <object width="0.2" X="5.5" Y="0.9" height="1.6" type="RectObject">
+            <object width="0.2" X="5.5" Y="0.9" height="1.6" type="Floor">
                 <property key="Bounciness">0.2</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.2" X="4.79" Y="1.0" height="1.4" type="RectObject">
+            <object width="0.2" X="4.79" Y="1.0" height="1.4" type="Floor">
                 <property key="Bounciness">0.2</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object X="5.168435573577881" Y="0.35" type="ColaMintBottle" angle="3.1415">
                 <property key="Bounciness">0.1</property>
@@ -117,9 +115,8 @@
                 <property key="ImageName">DarkerGreen</property>
             </object>
             <object X="3.1" Y="2.5" type="BowlingBall"/>
-            <object width="0.1" X="3.1" Y="2.35" height="0.1" type="RectObject">
+            <object width="0.1" X="3.1" Y="2.35" height="0.1" type="Floor">
                 <property key="Bounciness">0.0</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object X="2.8" Y="2.55" type="DominoBlue"/>
             <object X="2.5" Y="2.55" type="DominoBlue"/>

--- a/levels/jumpingjack/party-at-office.xml
+++ b/levels/jumpingjack/party-at-office.xml
@@ -114,19 +114,16 @@
                 <property key="object1">rope1@(0.00,-0.23)</property>
                 <property key="object2">rope2@(0.0,0.08)</property>
             </object>
-            <object X="2.9" height="0.1" type="RectObject" width="0.6" Y="0.49" angle="0">
+            <object X="2.9" height="0.1" type="BirchBar" width="0.6" Y="0.49" angle="0">
                 <property key="Bounciness">0.0</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="Mass">1.0</property>
                 <property key="PivotPoint">(-0.3,-0.05)</property>
             </object>
-            <object X="2.3" height="0.1" type="RectObject" width="0.6" Y="0.49" angle="0">
+            <object X="2.3" height="0.1" type="Floor" width="0.6" Y="0.49" angle="0">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object X="3.55" height="0.1" type="RectObject" width="0.6" Y="0.49" angle="0">
+            <object X="3.55" height="0.1" type="Floor" width="0.6" Y="0.49" angle="0">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object X="3.15" height="0.34" type="BowlingPin" width="0.12" Y="0.27" angle="0" ID="pin">
                 <property key="Bounciness">0.0</property>
@@ -145,9 +142,7 @@
                 <tooltip>Send the gift to the Jumping Jack!</tooltip>
             </object>
             <object X="0.575" height="0.1" type="Floor" width="0.393" Y="1.103" angle="0.366"/>
-            <object X="0.05" height="1.8" type="RectObject" width="0.1" Y="1" angle="0">
-                <property key="ImageName">used_wood_bar</property>
-            </object>
+            <object X="0.05" height="1.8" type="Floor" width="0.1" Y="1" angle="0"/>
             <object X="1.184" height="0.309" type="Link" width="0.464" Y="1.487" angle="0">
                 <property key="ImageName">shortballoonrope</property>
                 <property key="ZValue">10.0</property>

--- a/levels/picnic/picnic-1.xml
+++ b/levels/picnic/picnic-1.xml
@@ -20,9 +20,7 @@
     <scene>
         <scenesize width="6.5" height="4"/>
         <predefined>
-            <object width="0.200" X="0.100" Y="2.000" height="4.000" type="RectObject" angle="0.000">
-                <property key="ImageName">oldbrick</property>
-            </object>
+            <object width="0.200" X="0.100" Y="2.000" height="4.000" type="Wall" angle="0.000"/>
             <object width="1.400" X="0.710" Y="3.950" height="0.100" type="Floor" angle="0.000"/>
             <object width="0.800" X="0.500" Y="3.600" height="0.800" type="QuarterArc80" angle="1.570"/>
             <object width="2.039" X="4.066" Y="0.693" height="0.100" type="Floor" angle="0.000"/>
@@ -39,7 +37,7 @@
             <object width="0.744" X="3.837" Y="0.354" height="0.100" type="Floor" angle="-1.056"/>
             <object width="0.754" X="4.364" Y="0.350" height="0.100" type="Floor" angle="1.056"/>
             <object width="0.728" X="4.833" Y="0.361" height="0.100" type="Floor" angle="-1.056"/>
-            <object width="0.800" X="3.500" Y="0.090" height="0.180" type="RectObject" angle="0.000">
+            <object width="0.800" X="3.500" Y="0.090" height="0.180" type="Floor" angle="0.000">
                 <property key="ImageName">rg1024_Grass_texture</property>
                 <property key="ZValue">20.0</property>
             </object>

--- a/levels/picnic/picnic-2.xml
+++ b/levels/picnic/picnic-2.xml
@@ -29,13 +29,11 @@
             <object width="0.068" X="2.178" Y="2.143" height="0.068" type="TennisBall" ID="le but" angle="0.000"/>
             <object width="0.068" X="4.869" Y="0.934" height="0.068" type="PetanqueBoule" ID="RightBoule" angle="0.000"/>
             <object width="0.400" X="4.072" Y="0.826" height="0.400" type="Weight" ID="RightWeight" angle="0.000"/>
-            <object width="1.000" X="4.500" Y="0.950" height="0.100" type="RectObject" ID="RightArm" angle="-0.290">
-                <property key="ImageName">birch_bar</property>
+            <object width="1.000" X="4.500" Y="0.950" height="0.100" type="BirchBar" ID="RightArm" angle="-0.290">
                 <property key="Mass">0.5</property>
                 <property key="PivotPoint">(0,0)</property>
             </object>
-            <object width="0.250" X="4.951" Y="0.892" height="0.100" type="RectObject" ID="RightArmEnd" angle="1.280">
-                <property key="ImageName">birch_bar</property>
+            <object width="0.250" X="4.951" Y="0.892" height="0.100" type="BirchBar" ID="RightArmEnd" angle="1.280">
                 <property key="Mass">0.5</property>
                 <property key="NoCollision">RightArm</property>
             </object>

--- a/levels/picnic/picnic-3.xml
+++ b/levels/picnic/picnic-3.xml
@@ -59,16 +59,14 @@
             <object width="0.260" X="3.940" Y="2.980" height="0.100" type="Floor" angle="0.570">
                 <property key="ImageName">Empty</property>
             </object>
-            <object width="0.100" X="5.260" Y="0.590" height="0.080" type="RectObject" ID="leftplatform" angle="-0.04">
+            <object width="0.100" X="5.260" Y="0.590" height="0.080" type="BirchBar" ID="leftplatform" angle="-0.04">
                 <property key="Mass">0.1</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="TranslationGuide">1.571</property>
                 <property key="ZValue">5.0</property>
                 <property key="NoCollision">rightplatform</property>
             </object>
-            <object width="0.100" X="5.340" Y="0.590" height="0.080" type="RectObject" ID="rightplatform" angle="3.18">
+            <object width="0.100" X="5.340" Y="0.590" height="0.080" type="BirchBar" ID="rightplatform" angle="3.18">
                 <property key="Mass">0.1</property>
-                <property key="ImageName">birch_bar</property>
                 <property key="TranslationGuide">1.571</property>
                 <property key="ZValue">5.0</property>
                 <property key="NoCollision">leftplatform</property>
@@ -77,8 +75,7 @@
             <object width="1.700" X="5.150" Y="1.595" height="0.100" type="Floor" ID="vertibar" angle="1.571">
                 <property key="NoCollision">top-lever</property>
             </object>
-            <object width="0.600" X="5.090" Y="2.480" height="0.100" type="RectObject" ID="top-lever" angle="0.590">
-                <property key="ImageName">birch_bar</property>
+            <object width="0.600" X="5.090" Y="2.480" height="0.100" type="BirchBar" ID="top-lever" angle="0.590">
                 <property key="Mass">1</property>
                 <property key="NoCollision">verti-bar</property>
                 <property key="PivotPoint">(0,0)</property>
@@ -92,16 +89,14 @@
             <object width="1.000" X="5.183" Y="3.142" height="0.100" type="Floor" angle="-1.139">
                 <property key="ImageName">Empty</property>
             </object>
-            <object width="0.260" X="4.580" Y="2.514" height="0.100" type="RectObject" ID="reversehammer1" angle="-1.571">
-                <property key="ImageName">hammer</property>
+            <object width="0.260" X="4.580" Y="2.514" height="0.100" type="Hammer" ID="reversehammer1" angle="-1.571">
                 <property key="Mass">2</property>
                 <property key="PivotPoint">(0.05,0)</property>
             </object>
             <object width="2.535" X="3.229" Y="2.189" height="0.100" type="Floor" angle="0.000"/>
-            <object width="1.230" X="3.400" Y="1.690" height="0.120" type="RectObject" angle="6.050">
+            <object width="1.230" X="3.400" Y="1.690" height="0.120" type="BirchBar" angle="6.050">
                 <property key="Mass">2.0</property>
                 <property key="PivotPoint">(-0.1,0.0)</property>
-                <property key="ImageName">birch_bar</property>
             </object>
             <object width="0.1" X="3.400" Y="1.690" height="0.1" type="Scenery">
                 <property key="ZVale">10</property>
@@ -120,10 +115,9 @@
             <object width="0.120" X="3.970" Y="1.420" height="0.120" type="RectObject" ID="blocker2" angle="0.000">
                 <property key="ImageName">brass-pin</property>
             </object>
-            <object width="1.200" X="3.380" Y="1.030" height="0.100" type="RectObject" angle="5.950">
+            <object width="1.200" X="3.380" Y="1.030" height="0.100" type="BirchBar" angle="5.950">
                 <property key="Mass">3</property>
                 <property key="PivotPoint">(-0.08,0)</property>
-                <property key="ImageName">birch_bar</property>
             </object>
             <object width="0.1" X="3.30" Y="1.06" height="0.1" type="Scenery">
                 <property key="ZVale">10</property>
@@ -133,8 +127,7 @@
             <object width="0.550" X="4.800" Y="1.300" height="0.200" type="LeftRamp" angle="0.000"/>
             <object width="0.540" X="4.33" Y="1.100" height="0.100" type="Floor" angle="0.010"/>
             <object width="0.600" X="4.30" Y="0.800" height="0.100" type="Floor" angle="0.000"/>
-            <object width="0.360" X="4.140" Y="1.360" height="0.100" type="RectObject" ID="reversehammer2" angle="-1.571">
-                <property key="ImageName">hammer</property>
+            <object width="0.360" X="4.140" Y="1.360" height="0.100" type="Hammer" ID="reversehammer2" angle="-1.571">
                 <property key="Mass">0.1</property>
                 <property key="NoCollision">reversehammer2w;blocker2</property>
                 <property key="PivotPoint">(0,0)</property>


### PR DESCRIPTION
Many levels have `RectObject`s for things which are pretty standard now, like floors, walls, birch bars, and so on. This is done for ensuring correct tooltips.
This PR replaces those `RectObject`s with more standard objects and removes the redundant `ImageName` property. Unique `RectObject`s for things like cola crates or boxes are unchanged.
In a few levels I also removed physics attributes like `Bounciness` where I thought there were not needed and can be removed without breaking things.
I have manually quickly playtested each level to make sure nothing gets broken.

This PR touches a lot of levels, so additional testing is appreciated.