### PR TITLE
Clean up level titles

### DIFF
--- a/levels/attic/bridge-3.xml
+++ b/levels/attic/bridge-3.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mydocument>
 <tbe-level>
     <levelinfo>
-        <title>Bridge the Gap III</title>
+        <title>Bridge the Gap 3</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
         <description>Throw the tennis ball and the bowling pin into the brown hole.</description>

--- a/levels/draft/bridge-2.xml
+++ b/levels/draft/bridge-2.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mydocument>
 <tbe-level>
     <levelinfo>
-        <title>Bridge the Gap II</title>
+        <title>Bridge the Gap 2</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
         <description>Throw the bowling ball and the bowling pin into the hole on the right.</description>

--- a/levels/draft/bridge_gap.xml
+++ b/levels/draft/bridge_gap.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mydocument>
 <tbe-level>
     <levelinfo>
-        <title>Bridge the Gap I</title>
+        <title>Bridge the Gap 1</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
         <description>Throw the football and the bowling pin into the brown hole.</description>

--- a/levels/draft/float-balloon-float.xml
+++ b/levels/draft/float-balloon-float.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mydocument>
 <tbe-level>
     <levelinfo>
-        <title>float balloon, float</title>
+        <title>Float, balloon, float!</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
         <description>Topple the pin.</description>

--- a/levels/draft/jumping_around-2.xml
+++ b/levels/draft/jumping_around-2.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mydocument>
 <tbe-level>
     <levelinfo>
-        <title>Jumping Around II</title>
+        <title>Jumping Around 2</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
         <description>Topple the bowling pin so it falls into the brown pit.</description>

--- a/levels/draft/jumping_around.xml
+++ b/levels/draft/jumping_around.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mydocument>
 <tbe-level>
     <levelinfo>
-        <title>Jumping Around I</title>
+        <title>Jumping Around 1</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
         <description>Put the pin into the chest.</description>

--- a/levels/draft/loopings2.xml
+++ b/levels/draft/loopings2.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mydocument>
 <tbe-level>
     <levelinfo>
-        <title>Loopings II</title>
+        <title>Loopings</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
         <description>Push the bowling pin into the goal.</description>

--- a/levels/games/supertuxkart.xml
+++ b/levels/games/supertuxkart.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE mydocument>
 <tbe-level>
     <levelinfo>
-        <title>Loopings</title>
+        <title>Racing Penguin</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
         <description>Help Tux the racing penguin get to the cone fast!</description>


### PR DESCRIPTION
Some level names are cleaned up by this PR, especially regarding numbering and spelling. Roman numerals are replaced by arabic digits for consistency.

Renamed levels:

* Bridge The Gap I → Bridge The Gap 1
* Bridge The Gap II → Bridge The Gap 2
* Bridge The Gap III → Bridge The Gap 3
* Jumping Around I → Jumping Around 1
* Jumping Around II → Jumping Around 2
* float ballon, float → Float, balloon, float!
* Loopings (`levels/games/supertuxkart.xml`) → Racing Penguin
* Loopings II (`levels/draft/loopings-2.xml`) → Loopings

The last level was named “Loopings” because it is the only remaining level with “Loopings” in its name.