### PR TITLE
Show cursor coordinates in level creator

### DIFF
--- a/src/view/MainWindow.cpp
+++ b/src/view/MainWindow.cpp
@@ -58,6 +58,7 @@ MainWindow::MainWindow(bool isMaximized, QWidget *parent)
         on_action_Switch_to_Level_Editor_triggered();
     if (isMaximized)
         showMaximized();
+    statusBar();
 }
 
 
@@ -447,7 +448,7 @@ void MainWindow::setupView()
     setLanguageCheckmark();
 
 
-    ui->graphicsView->setup(this, ui->menuBar, ui->menuControls);
+    ui->graphicsView->setup(this, ui->menuBar, ui->menuControls, statusBar());
 
 	if (theIsRunAsRegression)
     {

--- a/src/view/MainWindow.cpp
+++ b/src/view/MainWindow.cpp
@@ -54,11 +54,14 @@ MainWindow::MainWindow(bool isMaximized, QWidget *parent)
 {
     ui->setupUi(this);
     setupView();
-    if (theIsLevelCreator)
+    statusBar();
+    if (theIsLevelCreator) {
         on_action_Switch_to_Level_Editor_triggered();
+    } else
+        statusBar()->hide();
+
     if (isMaximized)
         showMaximized();
-    statusBar();
 }
 
 
@@ -337,6 +340,7 @@ void MainWindow::on_action_Switch_to_Level_Editor_triggered()
     theLevelCreator = new LevelCreator(this);
     if (theLevelPtr)
         repopulateSceneAndToolbox();
+    statusBar()->show();
 }
 
 

--- a/src/view/MainWindow.cpp
+++ b/src/view/MainWindow.cpp
@@ -50,6 +50,7 @@ MainWindow::MainWindow(bool isMaximized, QWidget *parent)
       ui(new Ui::MainWindow),
       theLevelPtr(nullptr),
       theWorldPtr(nullptr),
+      theMousePosLabelPtr(nullptr),
       theLanguagesGroup(this)
 {
     ui->setupUi(this);
@@ -338,11 +339,21 @@ void MainWindow::on_action_Switch_to_Level_Editor_triggered()
     // everything is in the constructor of LevelCreator now...
     Q_ASSERT(nullptr == theLevelCreator);
     theLevelCreator = new LevelCreator(this);
-    if (theLevelPtr)
+    theMousePosLabelPtr = new QLabel(tr("Coordinates: –"));
+    statusBar()->addPermanentWidget(theMousePosLabelPtr);
+    if (theLevelPtr) {
         repopulateSceneAndToolbox();
+    }
     statusBar()->show();
 }
 
+void MainWindow::on_action_mouse_move(qreal x, qreal y)
+{
+    if (theIsLevelCreator && theMousePosLabelPtr != nullptr) {
+	//: Shows the cursor coordinates as decimal numbers. %1 is x, %1 is y. The comma seperates both numbers, the translation may need a different seperator
+	theMousePosLabelPtr->setText(tr("Coordinates: (%1,%2)").arg(QString::number(x, 'f', 3), QString::number(y, 'f', 3)));
+    }
+}
 
 void MainWindow::on_switchLanguage(QString aNewLanguage)
 {
@@ -452,7 +463,7 @@ void MainWindow::setupView()
     setLanguageCheckmark();
 
 
-    ui->graphicsView->setup(this, ui->menuBar, ui->menuControls, statusBar());
+    ui->graphicsView->setup(this, ui->menuBar, ui->menuControls);
 
 	if (theIsRunAsRegression)
     {

--- a/src/view/MainWindow.h
+++ b/src/view/MainWindow.h
@@ -23,6 +23,7 @@
 #include <QListWidget>
 #include <QMainWindow>
 #include <QTimer>
+#include <QLabel>
 
 namespace Ui {
 class MainWindow;
@@ -97,6 +98,12 @@ public slots:
     /// Because we have the filename already, no need to specify here.
 	void reloadLevel();
 
+    /// To be called when the cursor changed position in the graphicsview,
+    /// in order to display the coordinates.
+    /// x and y hold the world position of the cursor
+    void on_action_mouse_move(qreal x, qreal y);
+
+
 private slots:
 	/// Inserts one of the hints from the level into the Scene.
 	/// @note: for now, this is an internal function, usable by the
@@ -141,6 +148,9 @@ private:
     Level* theLevelPtr;
 
     World* theWorldPtr;
+
+    /// Label showing the world coordinates of the cursor. Only used in level creator
+    QLabel* theMousePosLabelPtr;
 
     /// This ActionGroup ensures that only one language in the menu is checked.
     QActionGroup theLanguagesGroup;

--- a/src/view/resizinggraphicsview.cpp
+++ b/src/view/resizinggraphicsview.cpp
@@ -46,8 +46,7 @@ ResizingGraphicsView::ResizingGraphicsView(QWidget *aParentPtr) :
     theMainWindowPtr(nullptr),
     theObjectEditorPtr(nullptr),
     theWinFailDialogPtr(nullptr),
-    theFrameRateViewPtr(nullptr),
-    theMousePosLabelPtr(nullptr)
+    theFrameRateViewPtr(nullptr)
 {
 	setAlignment(Qt::AlignLeft | Qt::AlignTop);
 	setDragMode(QGraphicsView::NoDrag);
@@ -108,19 +107,16 @@ void ResizingGraphicsView::resizeEvent(QResizeEvent *event)
 
 void ResizingGraphicsView::mouseMoveEvent(QMouseEvent *event)
 {
-	if (event!=nullptr)
+	if (event!=nullptr) {
 		QGraphicsView::mouseMoveEvent(event);
-	if (theMousePosLabelPtr==nullptr || !theIsLevelCreator)
-		return;
 
-	QPointF mousePos = this->mapToScene(event->pos());
-	Position p = Position(mousePos, 0);
-
-	//: Shows the cursor coordinates as decimal numbers. %1 is x, %1 is y. The comma seperates both numbers, the translation may need a different seperator
-	theMousePosLabelPtr->setText(tr("Coordinates: (%1,%2)").arg(QString::number(p.x, 'f', 3), QString::number(p.y, 'f', 3)));
+		QPointF mousePos = this->mapToScene(event->pos());
+		Position p = Position(mousePos, 0);
+		emit theMainWindowPtr->on_action_mouse_move(p.x, p.y);
+        }
 }
 
-void ResizingGraphicsView::setup(MainWindow* aMWPtr, QMenuBar* aMenuBarPtr, QMenu* anMenuControlsPtr, QStatusBar* aStatusBarPtr)
+void ResizingGraphicsView::setup(MainWindow* aMWPtr, QMenuBar* aMenuBarPtr, QMenu* anMenuControlsPtr)
 {
 	theMainWindowPtr = aMWPtr;
 	theSimControlsPtr->setup(anMenuControlsPtr);
@@ -131,9 +127,6 @@ void ResizingGraphicsView::setup(MainWindow* aMWPtr, QMenuBar* aMenuBarPtr, QMen
 
 	// this one displays the frame rate counter if active
 	theFrameRateViewPtr= aMenuBarPtr->addAction("");
-	//: Shown before the cursor is moved on the scene, after that the coordinates will be shown
-        theMousePosLabelPtr = new QLabel(tr("Coordinates: —"));
-	aStatusBarPtr->addPermanentWidget(theMousePosLabelPtr);
 }
 
 

--- a/src/view/resizinggraphicsview.cpp
+++ b/src/view/resizinggraphicsview.cpp
@@ -46,7 +46,8 @@ ResizingGraphicsView::ResizingGraphicsView(QWidget *aParentPtr) :
     theMainWindowPtr(nullptr),
     theObjectEditorPtr(nullptr),
     theWinFailDialogPtr(nullptr),
-    theFrameRateViewPtr(nullptr)
+    theFrameRateViewPtr(nullptr),
+    theMousePosLabelPtr(nullptr)
 {
 	setAlignment(Qt::AlignLeft | Qt::AlignTop);
 	setDragMode(QGraphicsView::NoDrag);
@@ -105,8 +106,21 @@ void ResizingGraphicsView::resizeEvent(QResizeEvent *event)
 	PieMenuSingleton::setViewInSceneCoords(mapToScene(rect()));
 }
 
+void ResizingGraphicsView::mouseMoveEvent(QMouseEvent *event)
+{
+	if (event!=nullptr)
+		QGraphicsView::mouseMoveEvent(event);
+	if(theMousePosLabelPtr==nullptr)
+		return;
 
-void ResizingGraphicsView::setup(MainWindow* aMWPtr, QMenuBar* aMenuBarPtr, QMenu* anMenuControlsPtr)
+	QPointF mousePos = this->mapToScene(event->pos());
+	Position p = Position(mousePos, 0);
+
+	//: Shows the cursor coordinates as decimal numbers. %1 is x, %1 is y. The comma seperates both numbers, the translation may need a different seperator
+	theMousePosLabelPtr->setText(tr("Coordinates: (%1,%2)").arg(QString::number(p.x, 'f', 3), QString::number(p.y, 'f', 3)));
+}
+
+void ResizingGraphicsView::setup(MainWindow* aMWPtr, QMenuBar* aMenuBarPtr, QMenu* anMenuControlsPtr, QStatusBar* aStatusBarPtr)
 {
 	theMainWindowPtr = aMWPtr;
 	theSimControlsPtr->setup(anMenuControlsPtr);
@@ -117,6 +131,9 @@ void ResizingGraphicsView::setup(MainWindow* aMWPtr, QMenuBar* aMenuBarPtr, QMen
 
 	// this one displays the frame rate counter if active
 	theFrameRateViewPtr= aMenuBarPtr->addAction("");
+	//: Shown before the cursor is moved on the scene, after that the coordinates will be shown
+        theMousePosLabelPtr = new QLabel(tr("Coordinates: —"));
+	aStatusBarPtr->addPermanentWidget(theMousePosLabelPtr);
 }
 
 

--- a/src/view/resizinggraphicsview.cpp
+++ b/src/view/resizinggraphicsview.cpp
@@ -110,7 +110,7 @@ void ResizingGraphicsView::mouseMoveEvent(QMouseEvent *event)
 {
 	if (event!=nullptr)
 		QGraphicsView::mouseMoveEvent(event);
-	if(theMousePosLabelPtr==nullptr)
+	if (theMousePosLabelPtr==nullptr || !theIsLevelCreator)
 		return;
 
 	QPointF mousePos = this->mapToScene(event->pos());

--- a/src/view/resizinggraphicsview.h
+++ b/src/view/resizinggraphicsview.h
@@ -26,7 +26,6 @@
 #include <QStatusBar>
 
 #include "AbstractObjectPtr.h"
-#include "Position.h"
 class EditObjectDialog;
 class GameResources;
 class MainWindow;

--- a/src/view/resizinggraphicsview.h
+++ b/src/view/resizinggraphicsview.h
@@ -21,9 +21,8 @@
 
 #include <QGraphicsView>
 #include <QResizeEvent>
-#include <QMouseEvent>
-#include <QLabel>
 #include <QStatusBar>
+#include <QMouseEvent>
 
 #include "AbstractObjectPtr.h"
 class EditObjectDialog;
@@ -59,8 +58,7 @@ public:
     /// @param aMWPtr
     /// @param aMenuBarPtr
     /// @param aMenuControlsPtr
-    /// @param aStatusBarPtr
-    void setup(MainWindow* aMWPtr, QMenuBar* aMenuBarPtr, QMenu* anMenuControlsPtr, QStatusBar* aStatusBarPtr);
+    void setup(MainWindow* aMWPtr, QMenuBar* aMenuBarPtr, QMenu* anMenuControlsPtr);
 
     /// @returns a pointer to the GameResourcesDialog.
     /// @note this member is only used to hand a pointer to Level.
@@ -94,7 +92,6 @@ private:
     ViewWorld*          theScenePtr;
     WinFailDialog*      theWinFailDialogPtr;
     QAction*            theFrameRateViewPtr;
-    QLabel*             theMousePosLabelPtr;
     friend class LevelCreator;
 };
 

--- a/src/view/resizinggraphicsview.h
+++ b/src/view/resizinggraphicsview.h
@@ -21,8 +21,12 @@
 
 #include <QGraphicsView>
 #include <QResizeEvent>
+#include <QMouseEvent>
+#include <QLabel>
+#include <QStatusBar>
 
 #include "AbstractObjectPtr.h"
+#include "Position.h"
 class EditObjectDialog;
 class GameResources;
 class MainWindow;
@@ -56,7 +60,8 @@ public:
     /// @param aMWPtr
     /// @param aMenuBarPtr
     /// @param aMenuControlsPtr
-    void setup(MainWindow* aMWPtr, QMenuBar* aMenuBarPtr, QMenu* anMenuControlsPtr);
+    /// @param aStatusBarPtr
+    void setup(MainWindow* aMWPtr, QMenuBar* aMenuBarPtr, QMenu* anMenuControlsPtr, QStatusBar* aStatusBarPtr);
 
     /// @returns a pointer to the GameResourcesDialog.
     /// @note this member is only used to hand a pointer to Level.
@@ -67,6 +72,7 @@ public:
 
 //protected:
     virtual void resizeEvent(QResizeEvent *event);
+    virtual void mouseMoveEvent(QMouseEvent *event);
 
 private slots:
     void slot_levelDeath(void);
@@ -89,6 +95,7 @@ private:
     ViewWorld*          theScenePtr;
     WinFailDialog*      theWinFailDialogPtr;
     QAction*            theFrameRateViewPtr;
+    QLabel*             theMousePosLabelPtr;
     friend class LevelCreator;
 };
 


### PR DESCRIPTION
This PR adds a status bar which currently has only one purpose: Showing the coordinates of the cursor in the current level. I think this simple addition makes editing a lot easier, especially for finding the correct coordinates for goals.

The status bar is hidden in the normal game since it is of no use here.

Maybe other stuff (debugging things) could be added later.