### PR TITLE
Add Cola Chaos, reorder recent levels by Wuzzy by difficulty

### DIFF
--- a/levels/levels.xml
+++ b/levels/levels.xml
@@ -18,6 +18,7 @@
    <level> draft/bridge_gap.xml </level>
    <level> draft/the_ball_the_box_and_the_penguin.xml </level>
    <level> draft/steam-machine.xml </level>
+   <level> elce09/10_kilograms_above_the_ground.xml </level>
    <level> draft/balloons-go-up.xml </level>
    <level> draft/balloons-do-poof.xml </level>
    <level> elce09/004.xml </level>
@@ -25,6 +26,7 @@
    <level> draft/little_balloon_puzzle.xml </level>
    <level> draft/styrofoam.xml </level>
    <level> jumpingjack/party-at-office.xml </level>
+   <level> draft/goal_maker.xml </level>
    <level> draft/in_the_attic.xml </level>
    <level> draft/poofpoofpoof.xml </level>
    <level> elce09/005.xml </level>
@@ -42,38 +44,37 @@
    <level> draft/float-balloon-float.xml </level>
    <level> draft/creativity.xml </level>
    <level> draft/bridge-2.xml </level>
+   <level> draft/hattrick.xml </level>
    <level> games/extreme-tux-racer.xml </level>
    <level> games/supertuxkart.xml </level>
    <level> games/pingus-1.xml </level>
    <level> draft/imperfectbalance.xml </level>
    <level> picnic/picnic-3.xml </level>
+   <level> draft/cola_reaction.xml</level>
    <level> draft/save-the-butterfly.xml</level>
    <level> draft/rotate_and_win.xml</level>
+   <level> draft/sorting-2.xml </level>
    <level> draft/construction_yard.xml</level>
    <level> draft/domino_day.xml </level>
    <level> draft/geyser.xml </level>
    <level> draft/butterfly-on-steroids.xml </level>
+   <level> draft/sorting-3.xml </level>
    <level> elce09/006.xml </level>
    <level> draft/contraption2.xml </level>
    <level> draft/balloon_blues.xml </level>
    <level> picnic/picnic-2.xml </level>
-   <level> draft/domino_chest.xml </level>
+   <level> draft/cola_chaos.xml </level>
+   <level> draft/sorting-4.xml </level>
    <level> draft/loopings2.xml </level>
+   <level> draft/domino_chest.xml </level>
    <level> elce09/007.xml </level>
+   <level> draft/boom_boom_boom.xml </level>
    <level> draft/hanging_box.xml </level>
    <level> draft/zoingandboom.xml </level>
-   <level> draft/find-the-message.v2.xml </level>
-   <level> draft/the_core.xml </level>
    <level> draft/butterflies_of_doom.xml </level>
-   <level> draft/the_pit.xml </level>
-   <level> draft/boom_boom_boom.xml </level>
-   <level> draft/goal_maker.xml </level>
-   <level> draft/hattrick.xml </level>
-   <level> draft/cola_reaction.xml </level>
-   <level> draft/butterfly_race.xml </level>
-   <level> draft/sorting-2.xml </level>
-   <level> draft/sorting-3.xml </level>
-   <level> draft/sorting-4.xml </level>
+   <level> draft/the_core.xml </level>
    <level> draft/sorting-5.xml </level>
-   <level> elce09/10_kilograms_above_the_ground.xml </level>
+   <level> draft/butterfly_race.xml </level>
+   <level> draft/the_pit.xml </level>
+   <level> draft/find-the-message.v2.xml </level>
 </tbe-levels>


### PR DESCRIPTION
Cola Chaos was oddly missing from the level list, so I added it.

I also think that we should not release milestone B with such a messy level list. There are hard and easy levels mixed up at the end, and Find the Message is not even the final level anymore.

So I ordered the new levels by me roughly by difficulty, because I think (especially) putting the easier levels at the very end was inappropriate. I consider The Pit to be the hardest level, so it is near the end.
The final level is Find The Message, because this is the “Good bye” level. ;-)

Note that because of difficulty shifts in the game, the post-it in “Double Action” is no longer true. Double Action is clearly not the “final big challenge” anymore. The strings are frozen, but we could do a little trick: By simply removing the first page of the post-it, it would become true again and it does not break any existing strings. I have not done this change because I am not sure about this idea.

If you object to any of those levels, please discuss. At least I can assure you that all levels in the list are solvable. I can proof it.
