### PR TITLE
Add 6 very easy to medium levels

### DIFF
--- a/levels/draft/birch_wood.xml
+++ b/levels/draft/birch_wood.xml
@@ -1,0 +1,96 @@
+<!DOCTYPE mydocument>
+<tbe-level>
+    <levelinfo>
+        <title>Birch Wood</title>
+        <author>Wuzzy</author>
+        <license>WTFPL</license>
+        <description>Roll the upper Pétanque ball to the other ones.</description>
+        <date>22.04.16</date>
+    </levelinfo>
+    <toolbox>
+        <toolboxitem count="1">
+            <object angle="0" width="1" height="0.1" type="Floor" X="0" Y="0"/>
+        </toolboxitem>
+        <toolboxitem count="1">
+            <object angle="0" width="1" height="0.1" type="BirchBar" X="0" Y="0"/>
+        </toolboxitem>
+        <toolboxitem count="1">
+            <object angle="0" width="1" height="0.356" type="LeftWedge" X="0" Y="0"/>
+        </toolboxitem>
+        <toolboxitem count="1">
+            <object angle="0" width="1" height="0.356" type="LeftFixedWedge" X="0" Y="0"/>
+        </toolboxitem>
+        <toolboxitem count="1">
+            <object angle="0" width="1" height="0.356" type="RightWedge" X="0" Y="0"/>
+        </toolboxitem>
+    </toolbox>
+    <scene>
+        <scenesize width="4.6" height="3"/>
+        <predefined>
+            <object angle="0" width="1" height="0.306" type="RightFixedWedge" X="1.04616" Y="2.68521"/>
+            <object angle="0" ID="ball" width="0.076" height="0.076" type="PetanqueBoule" X="0.737306" Y="2.90026"/>
+            <object angle="0" width="1" height="0.1" type="Floor" X="1.98721" Y="2.37436"/>
+            <object angle="0" width="1" height="0.1" type="BirchBar" X="3.01168" Y="2.37102"/>
+            <object angle="0" width="0.16574" height="0.1" type="Floor" X="2.5178" Y="2.14744"/>
+            <object angle="0" width="0.16574" height="0.1" type="Floor" X="3.506" Y="2.147"/>
+            <object angle="0" width="1.25695" height="0.1" type="Floor" X="3.88098" Y="1.61018"/>
+            <object angle="0" width="1.39356" height="0.1" type="Floor" X="2.65795" Y="1.10962"/>
+            <object angle="1.5708" width="0.399333" height="0.1" type="Floor" X="3.302" Y="1.3599"/>
+            <object angle="1.5708" width="0.312569" height="0.1" type="Floor" X="2.1401" Y="1.31702"/>
+            <object angle="0" width="0.16574" height="0.1" type="Floor" X="1.10957" Y="1.10962"/>
+            <object angle="0" width="1.11992" height="0.1" type="Floor" X="1.58687" Y="1.00951"/>
+            <object angle="0" width="3.30923" height="0.1" type="Floor" X="1.75028" Y="0.689155"/>
+            <object angle="1.5708" width="0.636262" height="0.1" type="Floor" X="0.145162" Y="0.320412"/>
+            <object angle="0" width="1.58065" height="0.1" type="Floor" X="0.799222" Y="2.00395"/>
+            <object angle="1.5708" width="0.269188" height="0.1" type="Floor" X="1.53943" Y="2.18966"/>
+            <object angle="0" width="2.60177" height="0.1" type="Floor" X="2.09033" Y="0.252002"/>
+            <object angle="0" width="0.592881" height="0.1" type="Floor" X="0.49188" Y="0.0517798"/>
+            <object angle="1.5708" width="0.19911" height="0.1" type="Floor" X="0.838321" Y="0.102336"/>
+            <object angle="0" width="0.076" height="0.076" type="PetanqueBoule" X="0.48002" Y="0.143869"/>
+            <object angle="0" width="0.076" height="0.076" type="PetanqueBoule" X="0.650209" Y="0.140532"/>
+            <object angle="0" width="0.076" height="0.076" type="PetanqueBoule" X="0.326516" Y="0.140532"/>
+            <object angle="0" width="0.22" height="0.22" type="PostIt" X="3.57154" Y="1.35663">
+                <property key="ZValue">1</property>
+                <property key="page1">Look what I’ve found in the cellar: A bunch of birch wood!</property>
+                <property key="page2">You already know the dark old wood: It is static and doesn’t move.</property>
+                <property key="page3">The bright birch wood, on the other hand, is subject to gravity.</property>
+                <property key="page4">Use the right wood at the right spots to solve this problem.</property>
+                <property key="page5">Post-It Boy</property>
+            </object>
+            <object angle="1.5708" width="1.64739" height="0.1" type="Floor" X="4.555" Y="0.838"/>
+            <object angle="0" width="0.34" height="0.34" type="Scenery" X="1.76" Y="2.158">
+                <property key="ImageName">SpidersWeb</property>
+                <property key="ZValue">1</property>
+            </object>
+            <object angle="-1.5708" width="0.5" height="0.5" type="Scenery" X="4.26571" Y="1.32333">
+                <property key="ImageName">SpidersWeb</property>
+                <property key="ZValue">1</property>
+            </object>
+        </predefined>
+        <background>
+            <gradientstop pos="0">0.662745;0.521569;0.282353;1</gradientstop>
+            <gradientstop pos="1">0.780392;0.619608;0.34902;1</gradientstop>
+        </background>
+    </scene>
+    <goals>
+        <goal isFail="false" type="positionchange">
+            <property key="object">ball</property>
+            <property key="xover">0.14</property>
+        </goal>
+        <goal isFail="false" type="positionchange">
+            <property key="object">ball</property>
+            <property key="xbelow">0.84</property>
+        </goal>
+        <goal isFail="false" type="positionchange">
+            <property key="object">ball</property>
+            <property key="ybelow">0.2</property>
+        </goal>
+    </goals>
+    <hints>
+        <hint object="Floor" X="2.708" number="1" Y="1.5401"/>
+        <hint object="LeftFixedWedge" X="3.83" number="2" Y="0.59"/>
+        <hint object="BirchBar" X="1.54004" number="3" Y="1.30973"/>
+        <hint object="RightWedge" X="0.582314" number="4" Y="1.00501"/>
+        <hint object="LeftWedge" X="4.00945" number="5" Y="1.96774"/>
+    </hints>
+</tbe-level>

--- a/levels/draft/box_puncher.xml
+++ b/levels/draft/box_puncher.xml
@@ -1,0 +1,67 @@
+<!DOCTYPE mydocument>
+<tbe-level>
+    <levelinfo>
+        <title>Box Puncher</title>
+        <author>Wuzzy</author>
+        <license>WTFPL</license>
+        <description>Push the cardboard box off the platform.</description>
+        <date>22.04.16</date>
+    </levelinfo>
+    <toolbox>
+        <toolboxitem count="1">
+            <object height="0.349" width="0.843" angle="0" type="LeftFixedWedge"/>
+        </toolboxitem>
+        <toolboxitem count="1">
+            <object height="0.1" width="0.446052" angle="0" type="Floor"/>
+        </toolboxitem>
+    </toolbox>
+    <scene>
+        <scenesize height="3" width="4.3"/>
+        <predefined>
+            <object height="0.1" X="2.569" width="3.34594" angle="0" type="Floor" Y="0.85"/>
+            <object height="0.1" X="3.73888" width="1" angle="0" type="Floor" Y="1.20973"/>
+            <object height="0.8" X="0.505172" width="0.8" angle="-3.1416" type="QuarterArc80" Y="1.20345"/>
+            <object ID="box" height="0.78809" X="3.74549" width="0.9" angle="0" type="CardboardBox" Y="1.65657">
+                <property key="ZValue">3</property>
+            </object>
+            <object height="0.22" X="0.317976" width="0.22" angle="0" type="BowlingBall" Y="2.68477"/>
+            <object height="1.25695" X="0.154449" width="0.106563" angle="0" type="Wall" Y="2.23304"/>
+            <object height="0.22" X="0.251235" width="0.22" angle="0" type="PostIt" Y="0.705907">
+                <property key="ZValue">1</property>
+                <property key="page1">A lot of new things are here, but they just make a huge mess.</property>
+                <property key="page2">Place your stuff at the right spots to keep things tidy.</property>
+                <property key="page3">Hint: To learn more about an object in the scene, just keep the cursor on it.</property>
+                <property key="page4">Post-It Boy</property>
+            </object>
+            <object height="0.1" X="1.64344" width="1.4" angle="0" type="IBeam" Y="1.89049"/>
+            <object height="0.1" X="2.42742" width="0.446052" angle="0" type="Floor" Y="1.717"/>
+            <object height="0.4" X="1.58773" width="0.25" angle="0" type="Cactus" Y="2.3445"/>
+            <object height="0.22" X="4.08216" width="0.22" angle="0" type="SoccerBall" Y="0.67921"/>
+            <object height="0.4" X="2.0133" width="0.4" angle="0" type="Weight" Y="2.34783"/>
+            <object height="0.5" X="1.93637" width="0.1" angle="0" type="DominoGreen" Y="0.39238"/>
+            <object height="0.1" X="2.32063" width="3.88988" angle="0" type="Floor" Y="0.0918242"/>
+            <object height="0.49277" X="3.77225" width="1" angle="0" type="LeftRamp" Y="0.389321"/>
+            <object height="0.6" X="0.890628" width="0.85" angle="0" type="ColaCrate" Y="0.442492"/>
+            <object height="0.21" X="1.25067" width="0.21" angle="0" type="VolleyBall" Y="2.24595"/>
+            <object height="0.36" X="2.43869" width="0.27" angle="0" type="Balloon" Y="2.32445"/>
+            <object height="0.5" X="2.29677" width="0.1" angle="0" type="DominoGreen" Y="0.395717"/>
+            <object height="0.5" X="1.58932" width="0.1" angle="0" type="DominoGreen" Y="0.39238"/>
+            <object height="0.228027" X="0.619939" width="0.15" angle="0" type="Butterfly" Y="2.7742"/>
+            <object height="0.068" X="3.69431" width="0.068" angle="0" type="TennisBall" Y="1.02217"/>
+        </predefined>
+        <background>
+            <gradientstop pos="0">0.576471;0.8;0.411765;1</gradientstop>
+            <gradientstop pos="1">0.741176;0.976471;0.564706;1</gradientstop>
+        </background>
+    </scene>
+    <goals>
+        <goal isFail="false" type="positionchange">
+            <property key="object">box</property>
+            <property key="xover">4.79</property>
+        </goal>
+    </goals>
+    <hints>
+            <hint number="1" X="0.888" object="Floor" Y="1.717"/>
+            <hint number="2" X="2.817" object="LeftFixedWedge" Y="1.078"/>
+    </hints>
+</tbe-level>

--- a/levels/draft/cola_addiction.xml
+++ b/levels/draft/cola_addiction.xml
@@ -1,0 +1,52 @@
+<!DOCTYPE mydocument>
+<tbe-level>
+    <levelinfo>
+        <title>Cola Addiction</title>
+        <author>Wuzzy</author>
+        <license>WTFPL</license>
+        <description>Put the tennis ball into the toy chest.</description>
+        <date>22.04.16</date>
+    </levelinfo>
+    <toolbox>
+        <toolboxitem count="10">
+            <object type="ColaCrate" angle="0" height="0.6" X="2.55403" Y="1.14388" width="0.85">
+                <property key="Rotatable">true</property>
+            </object>
+        </toolboxitem>
+    </toolbox>
+    <scene>
+        <scenesize height="3" width="5.9"/>
+        <predefined>
+            <object ID="ball" type="TennisBall" angle="0" height="0.068" X="0.214" Y="2.673" width="0.068"/>
+            <object type="RightRamp" angle="0" height="0.236917" X="0.3" Y="2.533" width="0.51273"/>
+            <object type="ToyChest" angle="0" height="1.7" X="5.053" Y="1.837" width="1">
+                <property key="ZValue">3</property>
+            </object>
+            <object type="Floor" angle="0" height="0.1" X="1.50924" Y="0.0524045" width="3"/>
+            <object type="Floor" angle="0" height="0.1" X="4.503" Y="0.052" width="3"/>
+        </predefined>
+        <background>
+            <gradientstop pos="0">0.792157;0.47451;0.47451;1</gradientstop>
+            <gradientstop pos="1">0.94902;0.564706;0.611765;1</gradientstop>
+        </background>
+    </scene>
+    <goals>
+        <goal isFail="false" type="positionchange">
+            <property key="object">ball</property>
+            <property key="xover">4.58</property>
+        </goal>
+        <goal isFail="false" type="positionchange">
+            <property key="object">ball</property>
+            <property key="xbelow">5.43</property>
+        </goal>
+        <goal isFail="false" type="positionchange">
+            <property key="object">ball</property>
+            <property key="yover">1.02</property>
+        </goal>
+        <goal isFail="false" type="positionchange">
+            <property key="object">ball</property>
+            <property key="ybelow">1.55</property>
+        </goal>
+    </goals>
+    <hints/>
+</tbe-level>

--- a/levels/draft/inversion.xml
+++ b/levels/draft/inversion.xml
@@ -1,0 +1,54 @@
+<!DOCTYPE mydocument>
+<tbe-level>
+    <levelinfo>
+        <title>Inversion</title>
+        <author>Wuzzy</author>
+        <license>WTFPL</license>
+        <description>Topple the cactus.</description>
+        <date>22.04.16</date>
+    </levelinfo>
+    <toolbox>
+        <toolboxitem count="1">
+            <object type="LeftRamp" angle="0" Y="0" width="1" height="0.325918" X="0"/>
+        </toolboxitem>
+        <toolboxitem count="1">
+            <object type="RightRamp" angle="0" Y="0" width="1" height="0.325918" X="0"/>
+        </toolboxitem>
+    </toolbox>
+    <scene>
+        <scenesize width="2.4" height="2.2"/>
+        <predefined>
+            <object type="Floor" angle="0" Y="1.00951" width="1" height="0.1" X="0.572326"/>
+            <object type="Floor" angle="0" Y="1.01" width="1" height="0.1" X="1.84"/>
+            <object type="PostIt" angle="0" Y="1.82715" width="0.22" height="0.22" X="1.21258">
+                <property key="ZValue">1</property>
+                <property key="page1">The wooden bar in the center is screwed on tightly and rotates around its own axis.</property>
+                <property key="page2">If you push the upper end towards one direction, the lower end will go the other way.</property>
+                <property key="page3">Post-It Boy</property>
+            </object>
+            <object type="RotatingBar" angle="-1.5708" Y="0.919" width="1" height="0.12" X="1.203"/>
+            <object type="Cactus" angle="0" Y="0.455729" width="0.25" height="0.4" ID="cactus" X="1.43451"/>
+            <object type="Floor" angle="0" Y="0.201947" width="2.23" height="0.1" X="1.21969"/>
+            <object type="VolleyBall" angle="0" Y="0.357" width="0.21" height="0.21" X="1.013"/>
+            <object type="SoccerBall" angle="0" Y="1.75374" width="0.22" height="0.22" X="2.22037"/>
+            <object type="SoccerBall" angle="0" Y="1.807" width="0.22" height="0.22" X="0.232"/>
+        </predefined>
+        <background>
+            <gradientstop pos="0">0.623529;0.866667;0.87451;1</gradientstop>
+            <gradientstop pos="1">0.713726;0.945098;0.984314;1</gradientstop>
+        </background>
+    </scene>
+    <goals>
+        <goal type="positionchange" isFail="false">
+            <property key="anglechanged"></property>
+            <property key="object">cactus</property>
+        </goal>
+        <goal type="positionchange" isFail="false">
+            <property key="object">cactus</property>
+            <property key="xover">1.7</property>
+        </goal>
+    </goals>
+    <hints>
+        <hint Y="1.26579" number="1" object="LeftRamp" X="1.81954"/>
+    </hints>
+</tbe-level>

--- a/levels/draft/pingu_poppins.xml
+++ b/levels/draft/pingu_poppins.xml
@@ -1,0 +1,97 @@
+<!DOCTYPE mydocument>
+<tbe-level>
+    <levelinfo>
+        <title>Pingu Poppins</title>
+        <author>Wuzzy</author>
+        <license>WTFPL</license>
+        <description>Pop all balloons.</description>
+        <date>22.04.16</date>
+    </levelinfo>
+    <toolbox>
+        <toolboxitem count="1">
+            <object angle="0" Y="2.4995" X="2.87152" height="0.1" type="Floor" width="1">
+                <property key="Resizable">horizontal</property>
+            </object>
+        </toolboxitem>
+        <toolboxitem count="1">
+            <object angle="0" Y="2.857" X="3.887" height="0.188" type="LeftRamp" width="0.561"/>
+        </toolboxitem>
+        <toolboxitem count="1">
+            <object angle="0" Y="2.23749" X="5.37931" height="0.187986" type="RightRamp" width="0.560623"/>
+        </toolboxitem>
+        <toolboxitem name="Styrofoam" count="2">
+            <object angle="0" Y="0" X="0" height="1" type="RectObject" width="1">
+                <property key="ImageName">styrofoam</property>
+                <property key="Mass">0.5</property>
+                <property key="Resizable">totalresize</property>
+                <tooltip>Styrofoam blocks are light and durable.</tooltip>
+            </object>
+        </toolboxitem>
+    </toolbox>
+    <scene>
+        <scenesize height="4" width="5.6"/>
+        <predefined>
+            <object angle="0" Y="3.318" X="2.872" height="0.28" type="Pingus" width="0.28"/>
+            <object angle="1.5708" Y="3.379" X="4.765" height="0.15" type="BedOfNails" width="0.8"/>
+            <object angle="-1.5708" Y="3.37861" X="0.925429" height="0.15" type="BedOfNails" width="0.8"/>
+            <object angle="0" Y="3.318" X="1.578" height="0.1" type="Floor" width="0.777"/>
+            <object angle="0" Y="2.797" X="0.911" height="0.188" type="LeftRamp" width="0.649988"/>
+            <object ID="b4" angle="0" Y="1.224" X="4.779" height="0.36" type="Balloon" width="0.27">
+                <property key="ImageName">BalloonYellow;BalloonPoof;BalloonRestYellow;Empty</property>
+            </object>
+            <object ID="b6" angle="0" Y="0.409" X="4.779" height="0.36" type="Balloon" width="0.27">
+                <property key="ImageName">BalloonRed;BalloonPoof;BalloonRestRed;Empty</property>
+            </object>
+            <object ID="b2" angle="0" Y="2" X="4.779" height="0.36" type="Balloon" width="0.27"/>
+            <object ID="b5" angle="0" Y="0.409" X="0.911" height="0.36" type="Balloon" width="0.27">
+                <property key="ImageName">BalloonRed;BalloonPoof;BalloonRestRed;Empty</property>
+            </object>
+            <object ID="b3" angle="0" Y="1.224" X="0.911" height="0.36" type="Balloon" width="0.27">
+                <property key="ImageName">BalloonYellow;BalloonPoof;BalloonRestYellow;Empty</property>
+            </object>
+            <object ID="b1" angle="0" Y="2" X="0.911" height="0.36" type="Balloon" width="0.27"/>
+            <object angle="0" Y="2.797" X="4.779" height="0.188" type="RightRamp" width="0.65"/>
+            <object angle="0" Y="3.37542" X="1.38025" height="0.801324" type="Scenery" width="1.05595">
+                <property key="ImageName">chickenwire-texture</property>
+                <property key="ZValue">3</property>
+            </object>
+            <object angle="0" Y="3.375" X="4.311" height="0.801324" type="Scenery" width="1.05595">
+                <property key="ImageName">chickenwire-texture</property>
+                <property key="ZValue">3</property>
+            </object>
+            <object angle="0" Y="3.312" X="4.078" height="0.1" type="Floor" width="0.777"/>
+        </predefined>
+        <background>
+            <gradientstop pos="0">0.976471;0.792157;0.756863;1</gradientstop>
+            <gradientstop pos="0.3">0.992157;1;0.666667;1</gradientstop>
+            <gradientstop pos="1">0.419608;0.647059;0.94902;1</gradientstop>
+        </background>
+    </scene>
+    <goals>
+        <goal type="statechange" isFail="false">
+            <property key="object">b1</property>
+            <property key="statechanged"></property>
+        </goal>
+        <goal type="statechange" isFail="false">
+            <property key="object">b2</property>
+            <property key="statechanged"></property>
+        </goal>
+        <goal type="statechange" isFail="false">
+            <property key="object">b3</property>
+            <property key="statechanged"></property>
+        </goal>
+        <goal type="statechange" isFail="false">
+            <property key="object">b4</property>
+            <property key="statechanged"></property>
+        </goal>
+        <goal type="statechange" isFail="false">
+            <property key="object">b5</property>
+            <property key="statechanged"></property>
+        </goal>
+        <goal type="statechange" isFail="false">
+            <property key="object">b6</property>
+            <property key="statechanged"></property>
+        </goal>
+    </goals>
+    <hints/>
+</tbe-level>

--- a/levels/draft/statics.xml
+++ b/levels/draft/statics.xml
@@ -1,0 +1,86 @@
+<!DOCTYPE mydocument>
+<tbe-level>
+    <levelinfo>
+        <title>Statics</title>
+        <author>Wuzzy</author>
+        <license>WTFPL</license>
+        <description>Topple the bowling pin.</description>
+        <date>22.04.16</date>
+    </levelinfo>
+    <toolbox>
+        <toolboxitem count="5">
+            <object angle="0" height="0.6" type="ColaCrate" X="1.44204" Y="1.01153" width="0.85"/>
+        </toolboxitem>
+        <toolboxitem count="4">
+            <object angle="0" height="0.1" type="IBeam" X="4.53366" Y="1.36273" width="1.4"/>
+        </toolboxitem>
+    </toolbox>
+    <scene>
+        <scenesize height="5.5" width="9"/>
+        <predefined>
+            <object angle="0" height="0.1" type="Floor" X="2.51" Y="0.055" width="5"/>
+            <object angle="0" height="0.1" type="Floor" X="2.65777" Y="3.30984" width="1.81"/>
+            <object angle="0" height="0.1" type="Floor" X="6.57397" Y="3.53565" width="1"/>
+            <object angle="0" height="0.22" type="BowlingBall" X="8.47812" Y="4.17291" width="0.22"/>
+            <object angle="0" height="0.408231" type="LeftRamp" X="7.85521" Y="3.79144" width="1.5762"/>
+            <object angle="0" height="0.1" type="Floor" X="2.658" Y="3.824" width="1.80979"/>
+            <object ID="pin" angle="0" height="0.34" type="BowlingPin" X="1.92943" Y="3.53245" width="0.12"/>
+            <object angle="0" height="0.6" type="ColaCrate" X="3.54259" Y="0.406235" width="0.85"/>
+            <object angle="0" height="0.6" type="ColaCrate" X="5.58854" Y="0.4126" width="0.85"/>
+            <object angle="0" height="0.794625" type="Scenery" X="1.02786" Y="4.79767" width="1.91485">
+                <property key="ImageName">clouds</property>
+                <property key="ZValue">1</property>
+            </object>
+            <object angle="0" height="0.794625" type="Scenery" X="2.72687" Y="4.79767" width="1.91485">
+                <property key="ImageName">clouds</property>
+                <property key="ZValue">1</property>
+            </object>
+            <object angle="0" height="0.794625" type="Scenery" X="4.34498" Y="4.79767" width="1.91485">
+                <property key="ImageName">clouds</property>
+                <property key="ZValue">1</property>
+            </object>
+            <object angle="0" height="0.794625" type="Scenery" X="5.988" Y="4.798" width="1.91485">
+                <property key="ImageName">clouds</property>
+                <property key="ZValue">1</property>
+            </object>
+            <object angle="0" height="0.794625" type="Scenery" X="7.787" Y="4.798" width="1.91485">
+                <property key="ImageName">clouds</property>
+                <property key="ZValue">1</property>
+            </object>
+            <object angle="0" height="0.6" type="ColaCrate" X="4.0035" Y="1.00693" width="0.85"/>
+            <object angle="0" height="0.4" type="Cactus" X="4.51772" Y="0.308699" width="0.25"/>
+            <object angle="0" height="0.6" type="ColaCrate" X="8.07" Y="0.407635" width="0.85"/>
+            <object angle="0" height="0.6" type="ColaCrate" X="1.442" Y="0.408" width="0.85"/>
+            <object angle="0" height="0.6" type="ColaCrate" X="8.07" Y="1.011" width="0.85"/>
+            <object angle="0" height="0.794625" type="Scenery" X="9.421" Y="4.798" width="1.91485">
+                <property key="ImageName">clouds</property>
+                <property key="ZValue">1</property>
+            </object>
+            <object angle="0" height="0.1" type="Floor" X="7.494" Y="0.055" width="5"/>
+            <object angle="0" height="0.4" type="Scenery" X="6.58183" Y="3.77207" width="1.00467">
+                <property key="ImageName">clouds</property>
+                <property key="ZValue">1</property>
+            </object>
+            <object angle="0" height="0.4" type="Scenery" X="2.61648" Y="3.54293" width="1.31019">
+                <property key="ImageName">clouds</property>
+                <property key="ZValue">1</property>
+            </object>
+            <object angle="0" height="0.457284" type="Scenery" X="2.66103" Y="4.08076" width="1.79392">
+                <property key="ImageName">clouds</property>
+                <property key="ZValue">1</property>
+            </object>
+        </predefined>
+        <background>
+            <gradientstop pos="0">0.65098;0.647059;0.647059;1</gradientstop>
+            <gradientstop pos="0.8">0.768627;0.768627;0.768627;1</gradientstop>
+            <gradientstop pos="0.9">0.784314;0.819608;0.929412;1</gradientstop>
+        </background>
+    </scene>
+    <goals>
+        <goal isFail="false" type="positionchange">
+            <property key="object">pin</property>
+            <property key="ybelow">1.6000000000000001</property>
+        </goal>
+    </goals>
+    <hints/>
+</tbe-level>


### PR DESCRIPTION
6 new levels for you, from very easy to medium.

These levels are easy or very easy and are intended to be used early in the game. Each level introduces a new concept (using post-it):

* Box Puncher: Introduces object tooltips (therefore, level should come _very_ early)
* Birch Wood: Introduces birch bars and birch wedges (in contrast to “static wood” = floors, etc.) (should be the first level containing birch and shoud come before any level with rotating bars, seesaws or `PivotPoint`s)
* Inversion: Introduces rotating bar (should be the first level with a rotating bar or anything with a `PivotPoint`)

Additional levels (medium difficulty, I guess):
* Pingu Poppins
* Cola Addiction
* Statics

Note about Pingu Poppins: I would like to put the pingu into the toolbox, but this doesn't work because of #209.