### PR TITLE
Make hammer in Butterflies of Doom less annoying

### DIFF
--- a/levels/draft/butterflies_of_doom.xml
+++ b/levels/draft/butterflies_of_doom.xml
@@ -43,7 +43,7 @@
         <scenesize width="5.7" height="3"/>
         <predefined>
             <object width="0.442" X="5.379" Y="0.097" height="0.174" type="RightRamp" angle="0.000"/>
-            <object X="2.359" Y="0.871" type="Hammer" angle="0.000"/>
+            <object X="2.440" Y="0.871" type="Hammer" angle="0.000"/>
             <object width="0.068" X="1.597" Y="1.898" height="0.068" type="TennisBall" angle="0.000"/>
             <object width="0.091" X="0.888" Y="2.571" height="0.100" type="Floor" angle="0.000"/>
             <object width="1.000" X="3.452" Y="0.492" height="0.100" type="Floor" angle="0.000"/>
@@ -51,7 +51,7 @@
             <object width="0.166" X="3.065" Y="0.798" height="0.500" type="ColaMintBottle" angle="0.000"/>
             <object width="0.200" X="2.149" Y="0.218" height="0.432" type="Wall" angle="0.000"/>
             <object width="0.262" X="0.762" Y="0.984" height="0.091" type="Floor" angle="0.000"/>
-            <object width="0.120" X="2.155" Y="0.608" height="0.340" type="BowlingPin" angle="0.000"/>
+            <object width="0.120" X="2.219" Y="0.608" height="0.340" type="BowlingPin" angle="0.000"/>
             <object width="0.200" X="1.404" Y="2.049" height="1.909" type="Wall" angle="0.000"/>
             <object width="0.220" X="0.762" Y="1.143" height="0.220" type="BowlingBall" angle="0.000"/>
             <object width="1.000" X="3.344" Y="1.301" height="0.069" type="BirchBar" angle="0.000"/>


### PR DESCRIPTION
The hammer in the level “Butterflies of Doom” was pretty unreliable to use and required lots of tweaking to get right. It is fixed by moving the hammer and bowling pin slightly to the left.
It should be now much easier to get right.

Fixes #211.