### PR TITLE
Add test levels for testing toolbox and objects

### DIFF
--- a/levels/test/test-objects.xml
+++ b/levels/test/test-objects.xml
@@ -1,0 +1,72 @@
+<!DOCTYPE mydocument>
+<tbe-level>
+    <levelinfo>
+        <title>Objects Test</title>
+        <author>Wuzzy</author>
+        <license>WTFPL</license>
+        <description>Test of objects with default properties in scene.</description>
+        <date>5/25/16</date>
+    </levelinfo>
+    <toolbox/>
+    <scene>
+        <scenesize width="9" height="5"/>
+        <predefined>
+            <object type="Balloon" angle="0" Y="2.93705" width="0.27" height="0.36" X="7.25743"/>
+            <object type="BedOfNails" angle="0" Y="2.96067" width="0.8" height="0.15" X="1.57174"/>
+            <object type="BirchBar" angle="0" Y="4.60579" width="1" height="0.1" X="7.38915"/>
+            <object type="BowlingBall" angle="0" Y="1.24176" width="0.22" height="0.22" X="1.0046"/>
+            <object type="Butterfly" angle="0" Y="4.51088" width="0.15" height="0.228027" X="1.40419"/>
+            <object type="Cactus" angle="0" Y="1.66096" width="0.25" height="0.4" X="2.70314"/>
+            <object type="CardboardBox" angle="0" Y="0.890716" width="0.9" height="0.78809" X="2.74077"/>
+            <object type="Floor" angle="0" Y="0.411624" width="1" height="0.1" X="2.72636"/>
+            <object type="ColaCrate" angle="0" Y="0.356078" width="0.85" height="0.6" X="7.94721"/>
+            <object type="CircularSaw" angle="0" Y="4.07304" width="0.38" height="0.38" X="1.70003"/>
+            <object type="ColaMintBottle" angle="0" Y="4.14831" width="0.166" height="0.5" X="6.26055"/>
+            <object type="DetonatorBox" angle="0" Y="0.178073" width="0.33" height="0.35" X="5.51671"/>
+            <object type="Dynamite" angle="0" Y="0.171021" width="0.43" height="0.32" X="6.07674"/>
+            <object type="DominoBlue" angle="0" Y="0.281146" width="0.1" height="0.5" X="6.61018"/>
+            <object type="DominoGreen" angle="0" Y="0.253337" width="0.1" height="0.5" X="7.02731"/>
+            <object type="DominoRed" angle="0" Y="0.286707" width="0.1" height="0.5" X="7.3332"/>
+            <object type="Hammer" angle="0" Y="2.90804" width="0.45" height="0.18" X="3.75964"/>
+            <object type="IBeam" angle="0" Y="4.27979" width="1.4" height="0.1" X="7.38114"/>
+            <object type="LeftFixedWedge" angle="0" Y="1.42158" width="1" height="1" X="7.5228"/>
+            <object type="LeftRamp" angle="0" Y="3.53065" width="1" height="1" X="1.57672"/>
+            <object type="LeftWedge" angle="0" Y="2.57832" width="1" height="1" X="7.54719"/>
+            <object type="PetanqueBoule" angle="0" Y="1.70975" width="0.076" height="0.076" X="0.615065"/>
+            <object type="Pingus" angle="0" Y="0.151991" width="0.28" height="0.28" X="2.83275"/>
+            <object type="PingusExit" angle="0" Y="0.503309" width="1" height="1" X="3.83615"/>
+            <object type="PostIt" angle="0" Y="4.04533" width="0.22" height="0.22" X="0.663719"/>
+            <object type="QuarterArc40" angle="0" Y="4.19041" width="0.4" height="0.4" X="3.41772"/>
+            <object type="QuarterArc80" angle="0" Y="4.37397" width="0.8" height="0.8" X="3.6171"/>
+            <object type="RightFixedWedge" angle="0" Y="1.41006" width="1" height="1" X="6.51886"/>
+            <object type="RightWedge" angle="0" Y="2.57276" width="1" height="1" X="6.53105"/>
+            <object type="RotatingBar" angle="0" Y="2.56792" width="1" height="0.12" X="3.40156"/>
+            <object type="SeesawSmall" angle="0" Y="2.08304" width="2.5" height="0.3" X="3.36902"/>
+            <object type="Skyhook" angle="0" Y="3.71982" width="0.2" height="0.23" X="3.36774"/>
+            <object type="SoccerBall" angle="0" Y="1.96413" width="0.22" height="0.22" X="0.370942"/>
+            <object type="Spring" angle="0" Y="0.113056" width="0.4" height="0.2" X="2.3723"/>
+            <object type="TennisBall" angle="0" Y="1.36415" width="0.068" height="0.068" X="0.753496"/>
+            <object type="ToyChest" angle="0" Y="0.858447" width="1" height="1.7" X="1.48899"/>
+            <object type="VolleyBall" angle="0" Y="2.37688" width="0.21" height="0.21" X="0.248498"/>
+            <object type="Wall" angle="0" Y="3.63889" width="0.2" height="1" X="7.28047"/>
+            <object type="Weight" angle="0" Y="1.31001" width="0.4" height="0.4" X="5.50356"/>
+            <object type="RightRamp" angle="0" Y="1.29607" width="1" height="1" X="0.5599"/>
+            <object type="CustomBall" angle="0" Y="2.86385" width="0.2" height="0.2" X="0.16012"/>
+            <object type="RectObject" angle="0" Y="3.29594" width="1" height="1" X="4.8026"/>
+            <object type="SleepingPingus" angle="0" Y="0.147284" width="0.28" height="0.28" X="4.56839"/>
+            <object type="PolyObject" angle="0" Y="4.43908" width="1" height="1" X="4.70639"/>
+            <object type="Scenery" angle="0" Y="3.62417" width="1" height="1" X="7.96605"/>
+            <object type="BowlingPin" angle="0" Y="0.387692" width="0.12" height="0.34" X="5.09385"/>
+        </predefined>
+        <background>
+            <gradientstop pos="0">0.8;0.8;1;1</gradientstop>
+            <gradientstop pos="1">0.494118;0.494118;0.894118;1</gradientstop>
+        </background>
+    </scene>
+    <goals>
+        <goal type="escapedPingusCount" isFail="false">
+            <property key="equalmore">1</property>
+        </goal>
+    </goals>
+    <hints/>
+</tbe-level>

--- a/levels/test/test-toolbox.xml
+++ b/levels/test/test-toolbox.xml
@@ -1,0 +1,66 @@
+<!DOCTYPE mydocument>
+<tbe-level>
+    <levelinfo>
+        <title>Toolbox Test</title>
+        <author>Wuzzy</author>
+        <license>WTFPL</license>
+        <description>Test of default objects in toolbox.</description>
+        <date>5/25/16</date>
+    </levelinfo>
+    <toolbox>
+        <toolboxitem count="1"><object type="Balloon"/></toolboxitem>
+        <toolboxitem count="1"><object type="BedOfNails"/></toolboxitem>
+        <toolboxitem count="1"><object type="BirchBar"/></toolboxitem>
+        <toolboxitem count="1"><object type="BowlingBall"/></toolboxitem>
+        <toolboxitem count="1"><object type="BowlingPin"/></toolboxitem>
+        <toolboxitem count="1"><object type="Butterfly"/></toolboxitem>
+        <toolboxitem count="1"><object type="Cactus"/></toolboxitem>
+        <toolboxitem count="1"><object type="CardboardBox"/></toolboxitem>
+        <toolboxitem count="1"><object type="ColaCrate"/></toolboxitem>
+        <toolboxitem count="1"><object type="CircularSaw"/></toolboxitem>
+        <toolboxitem count="1"><object type="ColaMintBottle"/></toolboxitem>
+        <toolboxitem count="1"><object type="DetonatorBox"/></toolboxitem>
+        <toolboxitem count="1"><object type="DominoBlue"/></toolboxitem>
+        <toolboxitem count="1"><object type="DominoRed"/></toolboxitem>
+        <toolboxitem count="1"><object type="DominoGreen"/></toolboxitem>
+        <toolboxitem count="1"><object type="Dynamite"/></toolboxitem>
+        <toolboxitem count="1"><object type="Floor"/></toolboxitem>
+        <toolboxitem count="1"><object type="Hammer"/></toolboxitem>
+        <toolboxitem count="1"><object type="IBeam"/></toolboxitem>
+        <toolboxitem count="1"><object type="LeftFixedWedge"/></toolboxitem>
+        <toolboxitem count="1"><object type="LeftRamp"/></toolboxitem>
+        <toolboxitem count="1"><object type="LeftWedge"/></toolboxitem>
+        <toolboxitem count="1"><object type="PetanqueBoule"/></toolboxitem>
+        <toolboxitem count="1"><object type="Pingus"/></toolboxitem>
+        <toolboxitem count="1"><object type="PingusExit"/></toolboxitem>
+        <toolboxitem count="1"><object type="QuarterArc40"/></toolboxitem>
+        <toolboxitem count="1"><object type="QuarterArc80"/></toolboxitem>
+        <toolboxitem count="1"><object type="RightFixedWedge"/></toolboxitem>
+        <toolboxitem count="1"><object type="RightRamp"/></toolboxitem>
+        <toolboxitem count="1"><object type="RightWedge"/></toolboxitem>
+        <toolboxitem count="1"><object type="RotatingBar"/></toolboxitem>
+        <toolboxitem count="1"><object type="SeesawSmall"/></toolboxitem>
+        <toolboxitem count="1"><object type="SleepingPingus"/></toolboxitem>
+        <toolboxitem count="1"><object type="Skyhook"/></toolboxitem>
+        <toolboxitem count="1"><object type="SoccerBall"/></toolboxitem>
+        <toolboxitem count="1"><object type="Spring"/></toolboxitem>
+        <toolboxitem count="1"><object type="TennisBall"/></toolboxitem>
+        <toolboxitem count="1"><object type="ToyChest"/></toolboxitem>
+        <toolboxitem count="1"><object type="VolleyBall"/></toolboxitem>
+        <toolboxitem count="1"><object type="Wall"/></toolboxitem>
+        <toolboxitem count="1"><object type="Weight"/></toolboxitem>
+    </toolbox>
+    <scene>
+        <scenesize width="8.5" height="5"/>
+        <background>
+            <gradientstop pos="0">0.8;0.8;1;1</gradientstop>
+            <gradientstop pos="1">0.494118;0.494118;0.894118;1</gradientstop>
+        </background>
+    </scene>
+    <goals>
+        <goal type="escapedPingusCount" isFail="false">
+            <property key="equalmore">1</property>
+        </goal>
+    </goals>
+    <hints/>
+</tbe-level>


### PR DESCRIPTION
This PR adds two test levels:

* Objects Test (`test-objects.xml`): Has most (sensible) objects in the level, with default properties only. Good to testing tooltips and whether something has gone terribly wrong
* Toolbox Test (`test-toolbox.xml`): Empty level, has most objects in the toolbox

I have added these to make some (manual) regression tests easier. For the future, those levels should be extended whenever a new object type is added, of course.

Note that the toolbox level currently exposes some bugs we already know:
* TBE crashes with `Pingus` or `PingusSleeping` in toolbox; the level works (for now) if those objects are removed (#209)
* Bad object names of `BedOfNails` and `CircularSaw` in toolbox (#237)

I hope those simple test levels will make it easier to find bugs and do quick tests. :)