### PR TITLE
Make levels introducing something appear first

### DIFF
--- a/levels/finished/jumping_around-2.xml
+++ b/levels/finished/jumping_around-2.xml
@@ -28,7 +28,7 @@
                 <property key="page1">Soccer balls are a little bouncy, but sometimes this is not enough.</property>
                 <property key="page2">I thought of using helium, but Mythbusters explained that it won’t work.</property>
                 <property key="page3">But fear not! There’s always a true mechanical solution.</property>
-                <property key="page4">Notice a new trick: rotate.</property>
+                <property key="page4">Note you can rotate your object here.</property>
                 <property key="page5">Post-It Boy</property>
             </object>
             <object width="4.400" X="2.200" Y="0.050" height="0.100" type="Floor" angle="0.000">

--- a/levels/levels.xml
+++ b/levels/levels.xml
@@ -15,19 +15,16 @@ box before birds-2).
    <level> needs-polish/brother-plays-soccer.xml </level>
    <level> needs-polish/bowling_pin_plays_soccer.xml </level> <!-- Introduces cola+mint bottle -->
    <level> finished/attack_of_the_killer_cacti.xml</level>
-   <level> needs-polish/brother-plays-penguin-goalie.xml </level>
    <level> finished/picnic-1.xml </level>
    <level> finished/jumping_around-2.xml </level>
    <level> finished/turn-it-around.xml </level>
    <level> finished/contraption1.xml </level>
    <level> finished/bridge_gap.xml </level>
-   <level> finished/the_ball_the_box_and_the_penguin.xml </level>
    <level> finished/steam-machine.xml </level>
    <level> finished/balloons-go-up.xml </level>
    <level> needs-polish/balloons-do-poof.xml </level>
    <level> needs-polish/004.xml </level>
    <level> finished/cola-powered-bike.v2.xml </level>
-   <level> finished/little_balloon_puzzle.xml </level>
    <level> needs-polish/styrofoam.xml </level> <!-- Introduces scaling in both axes -->
    <level> needs-polish/party-at-office.xml </level>
    <level> finished/in_the_attic.xml </level>
@@ -36,26 +33,29 @@ box before birds-2).
    <level> finished/volley_valley.xml </level>
    <level> finished/maze.xml </level>
    <level> finished/topple-the-other-way.xml </level>
-   <level> finished/pingus-introduction.xml </level> <!-- Introduces pingus and exit -->
    <level> finished/birds1.xml </level> <!-- Introduces dynamite and detonator box -->
    <level> finished/birds2.xml </level> <!-- Introduces changing detonator box' phone number -->
    <level> needs-polish/dialbforboom.xml </level>
+   <level> finished/pingus-introduction.xml </level> <!-- Introduces pingus and exit -->
+   <level> finished/pingus-1.xml </level>
    <level> finished/magic_steel.xml </level>
+   <level> needs-polish/brother-plays-penguin-goalie.xml </level>
+   <level> finished/domino_day.xml </level> <!-- Introduces scaling restricted to one axis only -->
    <level> finished/sorting-1.xml </level>
    <level> needs-polish/spare-the-balloon.xml </level>
+   <level> finished/the_ball_the_box_and_the_penguin.xml </level>
    <level> finished/controlled_detonation.xml </level>
    <level> finished/float-balloon-float.xml </level>
+   <level> finished/little_balloon_puzzle.xml </level>
    <level> finished/creativity.xml </level>
    <level> finished/bridge-2.xml </level>
    <level> needs-polish/extreme-tux-racer.xml </level>
    <level> finished/supertuxkart.xml </level>
-   <level> finished/pingus-1.xml </level>
    <level> needs-polish/imperfectbalance.xml </level>
    <level> finished/picnic-3.xml </level>
    <level> needs-polish/save-the-butterfly.xml</level>
    <level> finished/rotate_and_win.xml</level>
    <level> finished/construction_yard.xml</level>
-   <level> finished/domino_day.xml </level> <!-- Introduces scaling restricted to one axis only -->
    <level> needs-polish/geyser.xml </level>
    <level> needs-polish/butterfly-on-steroids.xml </level>
    <level> finished/006.xml </level>

--- a/levels/levels.xml
+++ b/levels/levels.xml
@@ -1,14 +1,19 @@
 <!DOCTYPE levellist>
+<!-- NOTE: When adding a level, make surre it is not placed
+before a level which introduces an element or concept
+it makes use of (e.g. a level with a configurable detonator
+box before birds-2).
+-->
 <tbe-levels>
-   <level> needs-polish/001.xml </level>
-   <level> finished/bouncing_balls.xml </level>
-   <level> needs-polish/002.xml </level>
+   <level> needs-polish/001.xml </level> <!-- Introduces post-it, butterfly, simulation controls. MUST BE FIRST LEVEL! -->
+   <level> finished/bouncing_balls.xml </level> <!-- Introduces toolbox. MUST BE SECOND LEVEL! -->
+   <level> needs-polish/002.xml </level> <!-- First level with a butterfly in danger -->
    <level> finished/jumping_around.xml </level>
    <level> finished/house_of_cards.xml </level>
    <level> finished/003.xml </level>
-   <level> finished/picnic-0.xml </level>
+   <level> finished/picnic-0.xml </level> <!-- Introduces rotation -->
    <level> needs-polish/brother-plays-soccer.xml </level>
-   <level> needs-polish/bowling_pin_plays_soccer.xml </level>
+   <level> needs-polish/bowling_pin_plays_soccer.xml </level> <!-- Introduces cola+mint bottle -->
    <level> finished/attack_of_the_killer_cacti.xml</level>
    <level> needs-polish/brother-plays-penguin-goalie.xml </level>
    <level> finished/picnic-1.xml </level>
@@ -23,7 +28,7 @@
    <level> needs-polish/004.xml </level>
    <level> finished/cola-powered-bike.v2.xml </level>
    <level> finished/little_balloon_puzzle.xml </level>
-   <level> needs-polish/styrofoam.xml </level>
+   <level> needs-polish/styrofoam.xml </level> <!-- Introduces scaling in both axes -->
    <level> needs-polish/party-at-office.xml </level>
    <level> finished/in_the_attic.xml </level>
    <level> needs-polish/poofpoofpoof.xml </level>
@@ -31,9 +36,9 @@
    <level> finished/volley_valley.xml </level>
    <level> finished/maze.xml </level>
    <level> finished/topple-the-other-way.xml </level>
-   <level> finished/pingus-introduction.xml </level>
-   <level> finished/birds1.xml </level>
-   <level> finished/birds2.xml </level>
+   <level> finished/pingus-introduction.xml </level> <!-- Introduces pingus and exit -->
+   <level> finished/birds1.xml </level> <!-- Introduces dynamite and detonator box -->
+   <level> finished/birds2.xml </level> <!-- Introduces changing detonator box' phone number -->
    <level> needs-polish/dialbforboom.xml </level>
    <level> finished/magic_steel.xml </level>
    <level> finished/sorting-1.xml </level>
@@ -50,7 +55,7 @@
    <level> needs-polish/save-the-butterfly.xml</level>
    <level> finished/rotate_and_win.xml</level>
    <level> finished/construction_yard.xml</level>
-   <level> finished/domino_day.xml </level>
+   <level> finished/domino_day.xml </level> <!-- Introduces scaling restricted to one axis only -->
    <level> needs-polish/geyser.xml </level>
    <level> needs-polish/butterfly-on-steroids.xml </level>
    <level> finished/006.xml </level>
@@ -62,7 +67,8 @@
    <level> needs-polish/007.xml </level>
    <level> finished/hanging_box.xml </level>
    <level> needs-polish/zoingandboom.xml </level>
-   <level> needs-polish/find-the-message.v2.xml </level>
+   <level> needs-polish/find-the-message.v2.xml </level> <!-- “Good-bye” level, should be the last level. -->
+   <!-- Chaos zone begins here, levels here are not well sorted (yet). -->
    <level> finished/the_core.xml </level>
    <level> finished/butterflies_of_doom.xml </level>
    <level> finished/the_pit.xml </level>


### PR DESCRIPTION
There were a few levels in the list which made use of concepts which weren't introduced before, e.g. pingus.
This PR basically just moves a few levels around so that those “introduction” levels appear first.
I also added comments into `levels.xml` to mark the interesting levels introducing something so new levels do not accidentally placed at bad positions

Please read for yourselves and tell me what you think about all this, thanks! :-)