### PR TITLE
I18N: Make undo/redo action texts a less awkward

### DIFF
--- a/src/control/AbstractUndoCommand.cpp
+++ b/src/control/AbstractUndoCommand.cpp
@@ -31,10 +31,9 @@ AbstractUndoCommand::AbstractUndoCommand(
 {
     AbstractObjectPtr myObjectPtr = theViewObjPtr->getAbstractObjectPtr();
 
-    // This is the undo action: %1 will contain e.g. "Move"
-    // and %2 might contain BowlingBall
-    setText( QString("%1 %2").arg(anUndoName)
-             .arg(myObjectPtr->getName()) );
+    // This is the undo action, anUndoName is e.g. “Move %s” and
+    // myObjectPtr->getName() is e.g. “Birch Bar”
+    setText( anUndoName.arg(myObjectPtr->getName()));
     theOrigPos    = theNewPos    = myObjectPtr->getOrigCenter();
     theOrigWidth  = theNewWidth  = myObjectPtr->getTheWidth();
     theOrigHeight = theNewHeight = myObjectPtr->getTheHeight();

--- a/src/control/ChoosePhoneUndoCommand.cpp
+++ b/src/control/ChoosePhoneUndoCommand.cpp
@@ -21,7 +21,7 @@
 
 ChoosePhoneUndoCommand::ChoosePhoneUndoCommand(
     ViewObjectPtr anViewObjectPtr)
-    : DummyUndoCommand(anViewObjectPtr, tr("ChoosePhone"))
+    : DummyUndoCommand(anViewObjectPtr, QObject::tr("Choose phone number of %1"))
 {
     DEBUG3ENTRY;
     ViewDetonatorBox *myPtr = dynamic_cast<ViewDetonatorBox *>(theViewObjPtr.data());

--- a/src/control/DeleteUndoCommand.cpp
+++ b/src/control/DeleteUndoCommand.cpp
@@ -29,7 +29,7 @@
 
 DeleteUndoCommand::DeleteUndoCommand(
     ViewObjectPtr anViewObjectPtr)
-    : InsertUndoCommand(anViewObjectPtr, QObject::tr("Remove"))
+    : InsertUndoCommand(anViewObjectPtr, QObject::tr("Remove %1"))
 {
     DEBUG3ENTRY;
     // The list of toolboxes is kept in Level as a QMap.

--- a/src/control/EditPropertyUndoCommand.cpp
+++ b/src/control/EditPropertyUndoCommand.cpp
@@ -24,7 +24,7 @@
 
 EditPropertyUndoCommand::EditPropertyUndoCommand(
     ViewObjectPtr anViewObjectPtr)
-    : AbstractUndoCommand(anViewObjectPtr, QObject::tr("EditProperty"))
+    : AbstractUndoCommand(anViewObjectPtr, QObject::tr("Edit property of %1"))
 {
     DEBUG3ENTRY;
 }

--- a/src/control/InsertUndoCommand.h
+++ b/src/control/InsertUndoCommand.h
@@ -33,7 +33,7 @@ class InsertUndoCommand : public AbstractUndoCommand
 {
 public:
     explicit InsertUndoCommand(ViewObjectPtr anViewObjectPtr,
-                               QString anActionString = QObject::tr("Insert"));
+                               QString anActionString = QObject::tr("Insert %1"));
 
     /// This static member creates an InsertUndoCommand from a Toolboxgroup pointer
     /// and an optional Hint pointer and handles everything - including the commit().

--- a/src/control/MoveUndoCommand.cpp
+++ b/src/control/MoveUndoCommand.cpp
@@ -26,7 +26,7 @@
 
 MoveUndoCommand::MoveUndoCommand(
     ViewObjectPtr anViewObjectPtr)
-    : AbstractUndoCommand(anViewObjectPtr, QObject::tr("Move"), nullptr)
+    : AbstractUndoCommand(anViewObjectPtr, QObject::tr("Move %1"), nullptr)
 {
     DEBUG3ENTRY;
     setDecoratorImage("ProxyMove");

--- a/src/control/ResizeUndoCommand.cpp
+++ b/src/control/ResizeUndoCommand.cpp
@@ -26,7 +26,7 @@
 
 ResizeUndoCommand::ResizeUndoCommand(
     ViewObjectPtr anViewObjectPtr)
-    : AbstractUndoCommand(anViewObjectPtr, QObject::tr("Resize"), nullptr),
+    : AbstractUndoCommand(anViewObjectPtr, QObject::tr("Resize %1"), nullptr),
       theButtonDownLength(999.f)
 {
     DEBUG3ENTRY;

--- a/src/control/RotateUndoCommand.cpp
+++ b/src/control/RotateUndoCommand.cpp
@@ -24,7 +24,7 @@
 
 RotateUndoCommand::RotateUndoCommand(
     ViewObjectPtr anViewObjectPtr)
-    : AbstractUndoCommand(anViewObjectPtr, QObject::tr("Rotate"), nullptr),
+    : AbstractUndoCommand(anViewObjectPtr, QObject::tr("Rotate %1"), nullptr),
       theButtonDownVectorAngle(999.f)
 {
     DEBUG3ENTRY;

--- a/src/view/MainWindow.cpp
+++ b/src/view/MainWindow.cpp
@@ -456,11 +456,11 @@ void MainWindow::setupView()
 {
     // setup UndoGroup's QActions and add them to Edit menu
     // note that this doesn't enable them yet, our ViewWorld should handle that...
-    QAction *myUndoActionPtr = UndoSingleton::createUndoAction(this, tr("&Undo"));
+    QAction *myUndoActionPtr = UndoSingleton::createUndoAction(this);
     myUndoActionPtr->setIcon(QIcon::fromTheme("edit-undo"));
     myUndoActionPtr->setShortcut(tr("Ctrl+Z"));
     ui->menuEdit->addAction(myUndoActionPtr);
-    QAction *myRedoActionPtr = UndoSingleton::createRedoAction(this, tr("&Redo"));
+    QAction *myRedoActionPtr = UndoSingleton::createRedoAction(this);
     myRedoActionPtr->setIcon(QIcon::fromTheme("edit-redo"));
     QList<QKeySequence> redoShortcuts;
     redoShortcuts << tr("Ctrl+Y") << tr("Shift+Ctrl+Z");


### PR DESCRIPTION
The action names of the undo and redo actions in the edit menu were pretty awkward and ungrammatical for other languages. For instance, in German it showed texts like “Rückgängig Bewegen Holzbalken”, which is hilariously ungrammatical.
With some use of format strings, translations should be now be slightly easier.

It is slightly better, but still a bit awkward, since Qt mindlessly concatenates “Undo” and the _action_ of the “undoing” (i.e. “Move Birch Bar”), which is of course bad for translation.

EDIT: The last paragraph doesn't apply anymore. Simply reverting to Qt's default undo/redo action strings did the trick. :-)
This means this PR now fixes the undo/redo texts for foreign languages.