### PR TITLE
Apply sane default Z-levels (#246)

### DIFF
--- a/src/model/Glue.cpp
+++ b/src/model/Glue.cpp
@@ -52,6 +52,7 @@ Glue::Glue() : AbstractJoint()
     theProps.setDefaultPropertiesString(
         Property::OBJECT1_STRING + QString(":/") +
         Property::OBJECT2_STRING + QString(":/") +
+        Property::ZVALUE_STRING + QString(":5.0/") +
         "-" + Property::MASS_STRING + ":/" );
     DEBUG5("Glue::Glue() end");
 }

--- a/src/model/Pingus.cpp
+++ b/src/model/Pingus.cpp
@@ -568,6 +568,8 @@ PingusExit::PingusExit()
     mySensorDef->isSensor = true;
     mySensorDef->userData = this;
     theShapeList.push_back(mySensorDef);
+    theProps.setDefaultPropertiesString(
+        Property::ZVALUE_STRING + QString(":0.5/") );
 }
 
 

--- a/src/model/PolyObject.cpp
+++ b/src/model/PolyObject.cpp
@@ -68,7 +68,7 @@ static AbstractPolyObjectFactory theSkyhookFactory(
     "Skyhook",
     "(-0.03,-0.07)=(0.01,-0.11)=(0.05,-0.11)=(0.1,-0.05)=(0.1,-0.02)"
     "=(0.08,0.00)=(-0.02,-0.03);(-0.10,0.12)",
-    0.20, 0.23, 0.0, 0.4 );
+    0.20, 0.23, 0.0, 0.4, Property::ZVALUE_STRING + QString(":1.0") );
 
 static AbstractPolyObjectFactory theWeightFactory(
     "Weight",
@@ -176,7 +176,7 @@ static AbstractPolyObjectFactory theToyChestFactory(
     "(0.3,-0.82)=(0.4,-0.82)=(0.4,-0.08)=(0.3,-0.10);"
     "(0.4,-0.08)=(0.45,0.0)=(0.45,0.18)=(0.38,0.45)=(0.2,0.75)=(0.12,0.80)=(0.04,0.82);"
     "(-0.4,-0.82)=(0.3,-0.82)=(0.3,-0.73)=(-0.4,-0.73)",
-    1.0, 1.7, 0.0, 0.05 );
+    1.0, 1.7, 0.0, 0.05, Property::ZVALUE_STRING + QString(":3.0") );
 
 static AbstractPolyObjectFactory theCardboardBoxFactory(
     "CardboardBox",
@@ -187,7 +187,7 @@ static AbstractPolyObjectFactory theCardboardBoxFactory(
     "(-0.40,-0.4)=(-0.35,-0.4)=(-0.35,0.40)=(-0.40,0.40);"
     "(0.35,-0.4)=(0.4,-0.4)=(0.4,0.40)=(0.35,0.40);"
     "(-0.35,-0.4)=(-0.35,-0.35)=(0.35,-0.35)=(0.35,-0.4)",
-    0.9, 0.78809, 0.5, 0.06 );
+    0.9, 0.78809, 0.5, 0.06, Property::ZVALUE_STRING + QString(":4.0") );
 
 static AbstractPolyObjectFactory theSmallSeesawFactory(
     "SeesawSmall",

--- a/src/model/PostIt.cpp
+++ b/src/model/PostIt.cpp
@@ -51,6 +51,7 @@ PostIt::PostIt( )
     // Note that PostIt doesn't have a physics representation
     // it is only graphics
     theProps.setDefaultPropertiesString(
+        Property::ZVALUE_STRING + QString(":1.5/") +
         QString("-") + Property::IMAGE_NAME_STRING + QString(":/") +
         "-" + Property::MASS_STRING + QString(":/") );
     theToolTip = QObject::tr("Someone left notes all over the place.\n"


### PR DESCRIPTION
Partial fix of #246.
The default properties are set in the property strings, and they show up as expected in the property editor when testing with `test-objects.xml`.

But for some reason, those new default Z-values don't have any effect on the actual ordering which you can clearly see in that test level. :-(
It's as if everything has still the default Z-level of `2.0`.