### PR TITLE
Add peg objects (immovable CircleObjects)

### DIFF
--- a/imagery/src/Balls/CMakeIncludeMe.txt
+++ b/imagery/src/Balls/CMakeIncludeMe.txt
@@ -9,5 +9,6 @@ install(FILES
 	${SRCDIRNAME}/steam-wheel.svg
         ${SRCDIRNAME}/TennisBall.png 
 	${SRCDIRNAME}/VolleyBall.svg 
+	${SRCDIRNAME}/wood-pin.svg 
         DESTINATION ${TBE_IMAGES_DIR}
 )

--- a/imagery/src/Balls/README
+++ b/imagery/src/Balls/README
@@ -49,3 +49,6 @@ license:   PD (Public Domain)
 Remix of Anonymous_Blue_bike.svg (RectObjects) to fit what's needed
 for TBE and make sure that it renders as expected in Qt's SVG engine.
 
+filename:  wood-pin.svg
+author:    Wuzzy, original work for The Butterfly Effect
+license:   WTFPL

--- a/imagery/src/Balls/wood-pin.svg
+++ b/imagery/src/Balls/wood-pin.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="443"
+   height="443"
+   id="svg2"
+   sodipodi:version="0.32"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="wood-pin.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0">
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.7486601"
+     inkscape:cx="155.20848"
+     inkscape:cy="189.06999"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1024"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     showguides="false" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3351">
+      <stop
+         style="stop-color:#cba767;stop-opacity:1"
+         offset="0"
+         id="stop3353" />
+      <stop
+         style="stop-color:#ad8740;stop-opacity:1"
+         offset="1"
+         id="stop3355" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3351"
+       id="radialGradient58159"
+       cx="461.52084"
+       cy="296.88736"
+       fx="461.52084"
+       fy="296.88736"
+       r="221.5"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3351"
+       id="radialGradient58159-0"
+       cx="461.52084"
+       cy="296.88736"
+       fx="461.52084"
+       fy="296.88736"
+       r="221.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.9908984e-4,-1.6535547e-4)" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:date>March 21, 2010</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Klaas van Gend</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1"
+     transform="translate(-240.02101,-75.387197)">
+    <circle
+       id="path2383-78"
+       style="fill:url(#radialGradient58159-0);fill-opacity:1;stroke:none;stroke-width:35.21757507;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       r="221.5"
+       cy="296.88721"
+       cx="461.521" />
+    <path
+       id="path2383"
+       style="fill:url(#radialGradient58159);fill-opacity:1.0;stroke:none;stroke-width:35.21757507;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       r="221.5"
+       cy="296.88736"
+       cx="461.52084" />
+    <circle
+       id="path2383-7"
+       style="opacity:0.074;fill:none;fill-opacity:1;stroke:#4f432f;stroke-width:13.23;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       cx="460.34702"
+       cy="301.03864"
+       r="177.4747" />
+    <circle
+       id="path2383-7-0"
+       style="opacity:0.024;fill:none;fill-opacity:1;stroke:#4f432f;stroke-width:7.05707359;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       cx="458.11389"
+       cy="297.31693"
+       r="88.017876" />
+    <circle
+       id="path2383-7-0-8"
+       style="opacity:0.044;fill:none;fill-opacity:1;stroke:#4f432f;stroke-width:10.55722618;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       cx="459.60263"
+       cy="297.31696"
+       r="131.67281" />
+  </g>
+</svg>

--- a/levels/finished/contraption2.xml
+++ b/levels/finished/contraption2.xml
@@ -57,7 +57,7 @@
                 <property key="object1">Bar</property>
                 <property key="object2">BrassPin</property>
             </object>
-            <object width="0.14" X="1.4" Y="2.48" height="0.14" type="Peg" angle="0"/>
+            <object width="0.14" X="1.4" Y="2.48" height="0.14" type="PegWood" angle="0"/>
             <object width="0.35" X="1.9" Y="2.46" height="0.1" type="Floor" angle="0.7">
                 <property key="Friction">0.8</property>
             </object>
@@ -93,7 +93,7 @@
             </object>
             <object width="0.22" X="0.25" Y="1.11" height="0.22" type="BowlingBall" angle="0"/>
             <object width="0.2" X="0.2" Y="1.01" height="0.15" type="RightRamp" angle="0"/>
-            <object width="0.14" X="0.7" Y="1.08" height="0.14" type="Peg" angle="0"/>
+            <object width="0.14" X="0.7" Y="1.08" height="0.14" type="PegWood" angle="0"/>
             <object width="1.4" X="3.05" Y="1.2" height="0.1" type="BirchBar" ID="Bar3" angle="0.2">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.1</property>

--- a/levels/finished/contraption2.xml
+++ b/levels/finished/contraption2.xml
@@ -57,9 +57,7 @@
                 <property key="object1">Bar</property>
                 <property key="object2">BrassPin</property>
             </object>
-            <object width="0.1" X="1.4" Y="2.5" height="0.1" type="Peg" angle="0">
-                <property key="Radius">0.05</property>
-            </object>
+            <object width="0.14" X="1.4" Y="2.48" height="0.14" type="Peg" angle="0"/>
             <object width="0.35" X="1.9" Y="2.46" height="0.1" type="Floor" angle="0.7">
                 <property key="Friction">0.8</property>
             </object>
@@ -95,9 +93,7 @@
             </object>
             <object width="0.22" X="0.25" Y="1.11" height="0.22" type="BowlingBall" angle="0"/>
             <object width="0.2" X="0.2" Y="1.01" height="0.15" type="RightRamp" angle="0"/>
-            <object width="0.1" X="0.7" Y="1.1" height="0.1" type="Peg" angle="0">
-                <property key="Radius">0.05</property>
-            </object>
+            <object width="0.14" X="0.7" Y="1.08" height="0.14" type="Peg" angle="0"/>
             <object width="1.4" X="3.05" Y="1.2" height="0.1" type="BirchBar" ID="Bar3" angle="0.2">
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.1</property>

--- a/levels/finished/contraption2.xml
+++ b/levels/finished/contraption2.xml
@@ -57,12 +57,8 @@
                 <property key="object1">Bar</property>
                 <property key="object2">BrassPin</property>
             </object>
-            <object width="0.1000000014901161" X="1.4" Y="2.5" height="0.1000000014901161" type="CustomBall" angle="0">
-                <property key="ImageName">brass-pin</property>
-                <property key="Mass">0</property>
+            <object width="0.1" X="1.4" Y="2.5" height="0.1" type="Peg" angle="0">
                 <property key="Radius">0.05</property>
-                <property key="ZValue">4.5</property>
-                <tooltip>A round obstacle, pinned to the sky.</tooltip>
             </object>
             <object width="0.35" X="1.9" Y="2.46" height="0.1" type="Floor" angle="0.7">
                 <property key="Friction">0.8</property>
@@ -99,12 +95,8 @@
             </object>
             <object width="0.22" X="0.25" Y="1.11" height="0.22" type="BowlingBall" angle="0"/>
             <object width="0.2" X="0.2" Y="1.01" height="0.15" type="RightRamp" angle="0"/>
-            <object width="0.1000000014901161" X="0.7" Y="1.1" height="0.1000000014901161" type="CustomBall" angle="0">
-                <property key="ImageName">brass-pin</property>
-                <property key="Mass">0</property>
+            <object width="0.1" X="0.7" Y="1.1" height="0.1" type="Peg" angle="0">
                 <property key="Radius">0.05</property>
-                <property key="ZValue">4.5</property>
-                <tooltip>A round obstacle, pinned to the sky.</tooltip>
             </object>
             <object width="1.4" X="3.05" Y="1.2" height="0.1" type="BirchBar" ID="Bar3" angle="0.2">
                 <property key="Bounciness">0.0</property>

--- a/levels/finished/picnic-1.xml
+++ b/levels/finished/picnic-1.xml
@@ -81,13 +81,7 @@
             <object width="6.4" X="5.2" Y="3.1" height="2.5" type="Scenery" angle="0.000">
                 <property key="ImageName">the-sun</property>
             </object>
-            <object width="0.14" X="2.5" Y="0.6" height="0.14" type="CustomBall">
-                <property key="Radius">0.07</property>
-                <property key="Bounciness">0.7</property>
-                <property key="ImageName">brass-pin</property>
-                <property key="Mass">0</property>
-                <tooltip>A round obstacle, pinned to the sky.</tooltip>
-            </object>
+            <object width="0.14" X="2.5" Y="0.6" height="0.14" type="Peg"/>
         </predefined>
         <background>
             <gradientstop pos="0.00">0.80;0.80;1.00;1.00</gradientstop>

--- a/levels/finished/picnic-1.xml
+++ b/levels/finished/picnic-1.xml
@@ -81,7 +81,7 @@
             <object width="6.4" X="5.2" Y="3.1" height="2.5" type="Scenery" angle="0.000">
                 <property key="ImageName">the-sun</property>
             </object>
-            <object width="0.14" X="2.5" Y="0.6" height="0.14" type="Peg"/>
+            <object width="0.14" X="2.5" Y="0.6" height="0.14" type="PegMetal"/>
         </predefined>
         <background>
             <gradientstop pos="0.00">0.80;0.80;1.00;1.00</gradientstop>

--- a/levels/finished/picnic-3.xml
+++ b/levels/finished/picnic-3.xml
@@ -117,9 +117,7 @@
             <object width="0.400" X="3.350" Y="0.500" height="0.100" type="Floor" angle="0.010"/>
             <object width="0.400" X="3.050" Y="0.400" height="0.100" type="Floor" angle="0.015"/>
             <object width="0.400" X="2.750" Y="0.300" height="0.100" type="Floor" angle="0.015"/>
-            <object width="0.120" X="3.970" Y="1.420" height="0.120" type="Peg" ID="blocker2" angle="0.000">
-                <property key="Radius">0.06</property>
-            </object>
+            <object width="0.140" X="3.970" Y="1.420" height="0.140" type="PegWood" ID="blocker2" angle="0.000"/>
             <object width="1.200" X="3.380" Y="1.030" height="0.100" type="BirchBar" angle="5.950">
                 <property key="Mass">3</property>
                 <property key="PivotPoint">(-0.08,0)</property>

--- a/levels/finished/picnic-3.xml
+++ b/levels/finished/picnic-3.xml
@@ -117,9 +117,8 @@
             <object width="0.400" X="3.350" Y="0.500" height="0.100" type="Floor" angle="0.010"/>
             <object width="0.400" X="3.050" Y="0.400" height="0.100" type="Floor" angle="0.015"/>
             <object width="0.400" X="2.750" Y="0.300" height="0.100" type="Floor" angle="0.015"/>
-            <object width="0.120" X="3.970" Y="1.420" height="0.120" type="RectObject" ID="blocker2" angle="0.000">
-                <property key="ImageName">brass-pin</property>
-                <tooltip>A round obstacle, pinned to the sky.</tooltip>
+            <object width="0.120" X="3.970" Y="1.420" height="0.120" type="Peg" ID="blocker2" angle="0.000">
+                <property key="Radius">0.06</property>
             </object>
             <object width="1.200" X="3.380" Y="1.030" height="0.100" type="BirchBar" angle="5.950">
                 <property key="Mass">3</property>

--- a/levels/needs-polish/picnic-2.xml
+++ b/levels/needs-polish/picnic-2.xml
@@ -8,14 +8,8 @@
         <date>5/7/12</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="3" name="Peg">
-            <object width="0.14" X="1.0" Y="2.7" height="0.14" type="CustomBall">
-                <tooltip>A round obstacle, pinned to the sky.</tooltip>
-                <property key="Radius">0.07</property>
-                <property key="Bounciness">0.7</property>
-                <property key="ImageName">brass-pin</property>
-                <property key="Mass">0</property>
-            </object>
+        <toolboxitem count="3">
+            <object type="Peg"/>
         </toolboxitem>
     </toolbox>
     <scene>

--- a/levels/needs-polish/picnic-2.xml
+++ b/levels/needs-polish/picnic-2.xml
@@ -9,7 +9,7 @@
     </levelinfo>
     <toolbox>
         <toolboxitem count="3">
-            <object type="Peg"/>
+            <object type="PegMetal"/>
         </toolboxitem>
     </toolbox>
     <scene>

--- a/levels/needs-polish/zoingandboom.xml
+++ b/levels/needs-polish/zoingandboom.xml
@@ -168,10 +168,10 @@
             <object X="0.943" Y="1.907" width="0.22" angle="0" type="BowlingBall" height="0.22"/>
             <object X="0.904" Y="1.706" width="0.105" angle="0" type="Floor" height="0.1"/>
             <object X="4.816" Y="2.598" width="0.4" angle="0" type="QuarterArc40" height="0.4"/>
-            <object X="2.22642" Y="1.57547" width="0.14" angle="0" type="Peg" height="0.14"/>
-            <object X="2.22642" Y="1.77547" width="0.14" angle="0" type="Peg" height="0.14"/>
-            <object X="2.84509" Y="0.60217" width="0.14" angle="0" type="Peg" height="0.14"/>
-            <object X="2.68943" Y="1.57151" width="0.14" angle="0" type="Peg" height="0.14"/>
+            <object X="2.22642" Y="1.57547" width="0.14" angle="0" type="PegMetal" height="0.14"/>
+            <object X="2.22642" Y="1.77547" width="0.14" angle="0" type="PegMetal" height="0.14"/>
+            <object X="2.84509" Y="0.60217" width="0.14" angle="0" type="PegMetal" height="0.14"/>
+            <object X="2.68943" Y="1.57151" width="0.14" angle="0" type="PegMetal" height="0.14"/>
         </predefined>
         <background>
             <gradientstop pos="0">0.24;0;0.43;1</gradientstop>

--- a/levels/needs-polish/zoingandboom.xml
+++ b/levels/needs-polish/zoingandboom.xml
@@ -168,34 +168,10 @@
             <object X="0.943" Y="1.907" width="0.22" angle="0" type="BowlingBall" height="0.22"/>
             <object X="0.904" Y="1.706" width="0.105" angle="0" type="Floor" height="0.1"/>
             <object X="4.816" Y="2.598" width="0.4" angle="0" type="QuarterArc40" height="0.4"/>
-            <object X="2.22642" Y="1.57547" width="0.14" angle="0" type="CustomBall" height="0.14">
-                <property key="Bounciness">0.7</property>
-                <property key="ImageName">brass-pin</property>
-                <property key="Mass">0</property>
-                <property key="Radius">0.07</property>
-                <tooltip>A round obstacle, pinned to the sky.</tooltip>
-            </object>
-            <object X="2.22642" Y="1.77547" width="0.14" angle="0" type="CustomBall" height="0.14">
-                <property key="Bounciness">0.7</property>
-                <property key="ImageName">brass-pin</property>
-                <property key="Mass">0</property>
-                <property key="Radius">0.07</property>
-                <tooltip>A round obstacle, pinned to the sky.</tooltip>
-            </object>
-            <object X="2.84509" Y="0.60217" width="0.14" angle="0" type="CustomBall" height="0.14">
-                <property key="Bounciness">0.7</property>
-                <property key="ImageName">brass-pin</property>
-                <property key="Mass">0</property>
-                <property key="Radius">0.07</property>
-                <tooltip>A round obstacle, pinned to the sky.</tooltip>
-            </object>
-            <object X="2.68943" Y="1.57151" width="0.14" angle="0" type="CustomBall" height="0.14">
-                <property key="Bounciness">0.7</property>
-                <property key="ImageName">brass-pin</property>
-                <property key="Mass">0</property>
-                <property key="Radius">0.07</property>
-                <tooltip>A round obstacle, pinned to the sky.</tooltip>
-            </object>
+            <object X="2.22642" Y="1.57547" width="0.14" angle="0" type="Peg" height="0.14"/>
+            <object X="2.22642" Y="1.77547" width="0.14" angle="0" type="Peg" height="0.14"/>
+            <object X="2.84509" Y="0.60217" width="0.14" angle="0" type="Peg" height="0.14"/>
+            <object X="2.68943" Y="1.57151" width="0.14" angle="0" type="Peg" height="0.14"/>
         </predefined>
         <background>
             <gradientstop pos="0">0.24;0;0.43;1</gradientstop>

--- a/levels/test/test-objects.xml
+++ b/levels/test/test-objects.xml
@@ -54,6 +54,7 @@
             <object X="5.50356" Y="1.31001" width="0.4" angle="0" type="Weight" height="0.4"/>
             <object X="0.5599" Y="1.29607" width="1" angle="0" type="RightRamp" height="1"/>
             <object X="0.16012" Y="2.86385" width="0.2" angle="0" type="CustomBall" height="0.2"/>
+            <object X="0.16012" Y="2.615" width="0.14" angle="0" type="Peg" height="0.14"/>
             <object X="4.8026" Y="3.29594" width="1" angle="0" type="RectObject" height="1"/>
             <object X="4.70639" Y="4.43908" width="1" angle="0" type="PolyObject" height="1"/>
             <object X="7.96605" Y="3.62417" width="1" angle="0" type="Scenery" height="1"/>

--- a/levels/test/test-toolbox.xml
+++ b/levels/test/test-toolbox.xml
@@ -30,6 +30,7 @@
         <toolboxitem count="1"><object type="LeftFixedWedge"/></toolboxitem>
         <toolboxitem count="1"><object type="LeftRamp"/></toolboxitem>
         <toolboxitem count="1"><object type="LeftWedge"/></toolboxitem>
+        <toolboxitem count="1"><object type="Peg"/></toolboxitem>
         <toolboxitem count="1"><object type="PetanqueBoule"/></toolboxitem>
         <toolboxitem count="1"><object type="PingusSleeping"/></toolboxitem>
         <toolboxitem count="1"><object type="PingusWalkLeft"/></toolboxitem>

--- a/src/model/CircleObjects.cpp
+++ b/src/model/CircleObjects.cpp
@@ -64,12 +64,18 @@ static CircleObjectFactory thePetanqueFactory("PetanqueBoule",
                                               "PetanqueBoule", 0.038, 0.700, 0.1);
 
 // size based on old version of picnic-2 level
-static CircleObjectFactory thePegFactory("Peg",
-                                         QT_TRANSLATE_NOOP("CircleObjectFactory", "Peg"),
+static CircleObjectFactory thePegMetalFactory("PegMetal",
+                                         QT_TRANSLATE_NOOP("CircleObjectFactory", "Metal Peg"),
                                          QT_TRANSLATE_NOOP("CircleObjectFactory",
-                                                           "A round obstacle, pinned to the sky."),
+                                                           "A round obstacle, pinned to the sky.\nThings will bounce off heavily."),
                                          "brass-pin", 0.07, 0.0, 0.7);
 
+// size based on old version of picnic-2 level
+static CircleObjectFactory thePegWoodFactory("PegWood",
+                                         QT_TRANSLATE_NOOP("CircleObjectFactory", "Wooden Peg"),
+                                         QT_TRANSLATE_NOOP("CircleObjectFactory",
+                                                           "A round obstacle, pinned to the sky.\nThings will bounce off weakly."),
+                                         "wood-pin", 0.07, 0.0, 0.1);
 
 // Constructors/Destructors
 //

--- a/src/model/CircleObjects.cpp
+++ b/src/model/CircleObjects.cpp
@@ -63,6 +63,14 @@ static CircleObjectFactory thePetanqueFactory("PetanqueBoule",
                                                                      "A pétanque ball is made of metal and is quite heavy."),
                                               "PetanqueBoule", 0.038, 0.700, 0.1);
 
+// size based on old version of picnic-2 level
+static CircleObjectFactory thePegFactory("Peg",
+                                         QT_TRANSLATE_NOOP("CircleObjectFactory", "Peg"),
+                                         QT_TRANSLATE_NOOP("CircleObjectFactory",
+                                                           "A round obstacle, pinned to the sky."),
+                                         "brass-pin", 0.07, 0.0, 0.7);
+
+
 // Constructors/Destructors
 //
 


### PR DESCRIPTION
This PR adds the peg (an immovable CircleObject) as requested in #123.
It comes in two flavors: Metal and wooden. The metal peg has high bounciness, the wooden one has low bounciness.
Levels are already updated to use the new pegs.

Please test before merging.