### PR TITLE
Add styrofoam block and styrofoam wedges

### DIFF
--- a/levels/finished/005.xml
+++ b/levels/finished/005.xml
@@ -21,14 +21,8 @@
                 <property key="Bounciness">0</property>
             </object>
         </toolboxitem>
-        <toolboxitem name="Styrofoam Block" count="1">
-            <object X="0" width="0.25" type="RectObject" Y="0" angle="0" height="0.8">
-                <property key="Bounciness">0.2</property>
-                <property key="Friction">0.3</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
+        <toolboxitem count="1">
+            <object X="0" width="0.25" type="Styrofoam" Y="0" angle="0" height="0.8"/>
         </toolboxitem>
     </toolbox>
     <scene>

--- a/levels/finished/contraption2.xml
+++ b/levels/finished/contraption2.xml
@@ -8,13 +8,8 @@
         <date>06/04/10</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="1" name="Right styrofoam wedge">
-            <object width="0.6" height="0.35" type="RightWedge">
-                <tooltip>A light and movable wedge made out of styrofoam.</tooltip>
-                <property key="ImageName">styrofoam-right</property>
-                <property key="Bounciness">0.3</property>
-                <property key="Mass">1.0</property>
-            </object>
+        <toolboxitem count="1">
+            <object width="0.6" height="0.35" type="RightStyrofoamWedge"/>
         </toolboxitem>
         <toolboxitem count="1">
             <object type="BowlingBall"/>

--- a/levels/finished/domino_day.xml
+++ b/levels/finished/domino_day.xml
@@ -17,15 +17,9 @@
         <toolboxitem count="1" icon="Domino-Stone-Red" name="Large Domino">
             <object width="0.1" height="0.7" type="DominoGreen"/>
         </toolboxitem>
-        <toolboxitem count="1" icon="styrofoam" name="Styrofoam Block">
-            <object width="0.8" height="0.1" type="RectObject">
-                <tooltip>Resizable styrofoam blocks … What an invention!</tooltip>
-                <property key="Friction">0.2</property>
-                <property key="Mass">0.2</property>
-                <property key="Bounciness">0.5</property>
-                <property key="ImageName">styrofoam</property>
+        <toolboxitem count="1">
+            <object width="0.8" height="0.1" type="Styrofoam">
                 <property key="Resizable">vertical</property>
-                <property key="Rotate">no</property>
             </object>
         </toolboxitem>
     </toolbox>

--- a/levels/finished/picnic-3.xml
+++ b/levels/finished/picnic-3.xml
@@ -154,26 +154,24 @@
             <object width="0.170" X="4.200" Y="0.460" height="0.500" type="ColaMintBottle" angle="1.810">
                 <property key="Thrust"> 2.5 </property>
             </object>
-            <object width="0.100" X="1.000" Y="0.360" height="0.720" type="RectObject" ID="Base" angle="0.00">
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">0.5</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
+            <object width="0.100" X="1.000" Y="0.360" height="0.720" type="Styrofoam" ID="Base" angle="0.00">
+                <property key="Bounciness">0.5</property>
             </object>
-            <object width="1.000" X="0.550" Y="0.770" height="0.100" type="RectObject" ID="Styro" angle="0.00">
-                <property key="ImageName">styrofoam</property>
+            <object width="1.000" X="0.550" Y="0.770" height="0.100" type="Styrofoam" ID="Styro" angle="0.00">
+                <property key="Bounciness">0.5</property>
                 <property key="NoCollision">Styro2,Styro3</property>
                 <property key="Mass">0.1</property>
                 <property key="PivotPoint">(-0.5,0.0)</property>
                 <tooltip>This piece of styrofoam is attached to something.</tooltip>
             </object>
-            <object width="1.050" X="0.550" Y="0.790" height="0.100" type="RectObject" ID="Styro2" angle="-0.05">
-                <property key="ImageName">styrofoam</property>
+            <object width="1.050" X="0.550" Y="0.790" height="0.100" type="Styrofoam" ID="Styro2" angle="-0.05">
+                <property key="Bounciness">0.5</property>
                 <property key="NoCollision">Styro,Styro3</property>
                 <property key="Mass">0.1</property>
                 <tooltip>This piece of styrofoam is attached to something.</tooltip>
             </object>
-            <object width="1.050" X="0.550" Y="0.790" height="0.100" type="RectObject" ID="Styro3" angle="0.05">
-                <property key="ImageName">styrofoam</property>
+            <object width="1.050" X="0.550" Y="0.790" height="0.100" type="Styrofoam" ID="Styro3" angle="0.05">
+                <property key="Bounciness">0.5</property>
                 <property key="NoCollision">Styro2,Styro3</property>
                 <property key="Mass">0.1</property>
                 <tooltip>This piece of styrofoam is attached to something.</tooltip>

--- a/levels/finished/pingu_poppins.xml
+++ b/levels/finished/pingu_poppins.xml
@@ -19,12 +19,9 @@
         <toolboxitem count="1">
             <object angle="0" Y="2.23749" X="5.37931" height="0.187986" type="RightRamp" width="0.560623"/>
         </toolboxitem>
-        <toolboxitem name="Styrofoam" count="2">
-            <object angle="0" Y="0" X="0" height="1" type="RectObject" width="1">
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">0.5</property>
+        <toolboxitem count="2">
+            <object angle="0" Y="0" X="0" width="1" height="0.5" type="Styrofoam">
                 <property key="Resizable">totalresize</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
             </object>
         </toolboxitem>
     </toolbox>

--- a/levels/finished/the_pit.xml
+++ b/levels/finished/the_pit.xml
@@ -104,11 +104,9 @@
             <object width="0.131607" height="0.101402" Y="5.41748" angle="0" type="RightFixedWedge" X="2.48004"/>
             <object width="0.109385" height="1.12837" Y="4.79072" angle="0" type="Wall" X="4.311"/>
             <object width="0.864078" height="0.1" Y="4.82163" angle="0" type="RotatingBar" ID="pingubar_h" X="3.76752" />
-            <object width="0.758533" height="0.1" Y="4.48527" angle="-1.57" type="RectObject" ID="pingubar_v" X="3.28156">
+            <object width="0.758533" height="0.1" Y="4.48527" angle="-1.57" type="Styrofoam" ID="pingubar_v" X="3.28156">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">styrofoam</property>
                 <property key="Mass">1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
             </object>
             <object width="0.04" height="0.1" Y="0" angle="-1.57" type="Glue" X="0">
                 <property key="ImageName">GlueBlob</property>
@@ -125,17 +123,13 @@
             <object width="0.713142" height="0.1" Y="1.49804" angle="-1.57" type="RotatingBar" ID="dominobar_left" X="1.68896" />
             <object width="2.66127" height="0.1" Y="0.842124" angle="0" type="Floor" X="2.84628"/>
             <object width="0.784938" height="0.777389" Y="1.07931" angle="-3.1415" type="QuarterArc40" X="1.13121"/>
-            <object width="1.26429" height="0.243474" Y="5.23317" angle="0" type="RectObject" X="6.32362">
+            <object width="1.26429" height="0.243474" Y="5.23317" angle="0" type="Styrofoam" X="6.32362">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">styrofoam</property>
                 <property key="Mass">1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
             </object>
-            <object width="1.24919" height="0.213269" Y="4.59886" angle="0" type="RectObject" X="6.33872">
+            <object width="1.24919" height="0.213269" Y="4.59886" angle="0" type="Styrofoam" X="6.33872">
                 <property key="Bounciness">0.1</property>
-                <property key="ImageName">styrofoam</property>
                 <property key="Mass">1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
             </object>
             <object width="1.23409" height="0.1" Y="5.05571" angle="0" type="Floor" X="7.06364"/>
             <object width="0.758361" height="0.1" Y="5.05571" angle="0" type="Floor" X="5.54207"/>

--- a/levels/needs-polish/007.xml
+++ b/levels/needs-polish/007.xml
@@ -41,11 +41,21 @@
             <object width="0.85" X="5.91" Y="3.73" height="0.86" type="Wall">
                 <property key="Friction">1</property>
             </object>
-            <object width="0.35" X="6.67" Y="4.1" height="1" type="Styrofoam"/>
-            <object width="0.35" X="6.63" Y="3.1" height="1" type="Styrofoam"/>
-            <object width="0.35" X="6.60" Y="2.1" height="1" type="Styrofoam"/>
-            <object width="0.35" X="6.67" Y="1.1" height="1" type="Styrofoam"/>
-            <object width="0.35" X="6.62" Y="0.35" height="0.5" type="Styrofoam"/>
+            <object width="0.35" X="6.67" Y="4.1" height="1" type="Styrofoam">
+                <property key="Mass">1</property>
+            </object>
+            <object width="0.35" X="6.63" Y="3.1" height="1" type="Styrofoam">
+                <property key="Mass">1</property>
+            </object>
+            <object width="0.35" X="6.60" Y="2.1" height="1" type="Styrofoam">
+                <property key="Mass">1</property>
+            </object>
+            <object width="0.35" X="6.67" Y="1.1" height="1" type="Styrofoam">
+                <property key="Mass">1</property>
+            </object>
+            <object width="0.35" X="6.62" Y="0.35" height="0.5" type="Styrofoam">
+                <property key="Mass">1</property>
+            </object>
             <object width="0.6" X="7.55" Y="1.94" height="3.65" type="Wall"/>
             <object width="0.2" X="5.5" Y="0.9" height="1.6" type="Floor">
                 <property key="Bounciness">0.2</property>

--- a/levels/needs-polish/007.xml
+++ b/levels/needs-polish/007.xml
@@ -14,15 +14,8 @@
                 <property key="Resizable">none</property>
             </object>
         </toolboxitem>
-        <toolboxitem count="1" name="Styrofoam Block">
-            <object width="0.25" height="0.8" type="RectObject">
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-                <property key="Friction">0.3</property>
-                <property key="Bounciness">0.2</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1</property>
-                <property key="Resizable">none</property>
-            </object>
+        <toolboxitem count="1">
+            <object width="0.25" height="0.8" type="Styrofoam"/>
         </toolboxitem>
         <toolboxitem count="1">
             <object width="1.0" height="0.5" type="LeftRamp" angle="0"/>
@@ -48,40 +41,11 @@
             <object width="0.85" X="5.91" Y="3.73" height="0.86" type="Wall">
                 <property key="Friction">1</property>
             </object>
-            <object width="0.35" X="6.67" Y="4.1" height="1" type="RectObject">
-                <property key="Bounciness">0.2</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
-            <object width="0.35" X="6.63" Y="3.1" height="1" type="RectObject">
-                <property key="Friction">0.1</property>
-                <property key="Bounciness">0.2</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
-            <object width="0.35" X="6.60" Y="2.1" height="1" type="RectObject">
-                <property key="Friction">0.1</property>
-                <property key="Bounciness">0.2</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
-            <object width="0.35" X="6.67" Y="1.1" height="1" type="RectObject">
-                <property key="Friction">0.1</property>
-                <property key="Bounciness">0.2</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
-            <object width="0.35" X="6.62" Y="0.35" height="0.5" type="RectObject">
-                <property key="Friction">0.1</property>
-                <property key="Bounciness">0.2</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
+            <object width="0.35" X="6.67" Y="4.1" height="1" type="Styrofoam"/>
+            <object width="0.35" X="6.63" Y="3.1" height="1" type="Styrofoam"/>
+            <object width="0.35" X="6.60" Y="2.1" height="1" type="Styrofoam"/>
+            <object width="0.35" X="6.67" Y="1.1" height="1" type="Styrofoam"/>
+            <object width="0.35" X="6.62" Y="0.35" height="0.5" type="Styrofoam"/>
             <object width="0.6" X="7.55" Y="1.94" height="3.65" type="Wall"/>
             <object width="0.2" X="5.5" Y="0.9" height="1.6" type="Floor">
                 <property key="Bounciness">0.2</property>
@@ -101,13 +65,8 @@
                 <property key="Bounciness">0.1</property>
                 <property key="Thrust">20</property>
             </object>
-            <object width="0.48" X="5.15" Y="0.83" height="0.5" type="RectObject">
-                <property key="Bounciness">0.1</property>
-                <property key="Friction">0.1</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="TranslationGuide">1.57</property>
-                <property key="Mass">1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
+            <object width="0.48" X="5.15" Y="0.83" height="0.5" type="Styrofoam">
+                <property key="TranslationGuide">1.5708</property>
             </object>
             <object width="1.7" X="4.1" Y="2" height="0.6" type="RightRamp" angle="0">
                 <property key="Bounciness">0.1</property>

--- a/levels/needs-polish/balloons-do-poof.xml
+++ b/levels/needs-polish/balloons-do-poof.xml
@@ -35,10 +35,7 @@
             </object>
             <object width="0.1" X="0.5" Y="1.05" height="1.9" type="Wall" angle="0"/>
             <object width="0.21" X="0.7" Y="1.86" height="0.21" type="VolleyBall" angle="0"/>
-            <object width="0.3" X="0.7" Y="0.7" height="0.3" type="RightWedge" angle="0">
-                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
-                <property key="Bounciness">0.6</property>
-                <property key="ImageName">styrofoam-right</property>
+            <object width="0.3" X="0.7" Y="0.7" height="0.3" type="RightStyrofoamWedge" angle="0">
                 <property key="Mass">0.2</property>
                 <property key="TranslationGuide">1.57</property>
             </object>

--- a/levels/needs-polish/butterfly-on-steroids.xml
+++ b/levels/needs-polish/butterfly-on-steroids.xml
@@ -143,12 +143,7 @@
                 <property key="Bounciness">0.0</property>
                 <property key="Friction">0.4</property>
             </object>
-            <object height="0.800" type="RectObject" X="3.700" width="0.150" Y="1.450" angle="0.000">
-                <property key="Bounciness">0.2</property>
-                <property key="Friction">0.1</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1</property>
-            </object>
+            <object height="0.800" type="Styrofoam" X="3.700" width="0.150" Y="1.450" angle="0.000"/>
             <object height="0.800" type="QuarterArc80" X="3.906" width="1.000" Y="2.206" angle="3.635"/>
             <object height="0.608" type="QuarterArc80" X="2.845" width="1.000" Y="2.414" angle="0.350"/>
             <object height="0.400" type="QuarterArc40" X="0.197" width="0.400" Y="2.015" angle="3.142"/>

--- a/levels/needs-polish/dialbforboom.xml
+++ b/levels/needs-polish/dialbforboom.xml
@@ -64,30 +64,10 @@
                 <property key="ImageName">DominoBlue</property>
                 <property key="Mass">1.0</property>
             </object>
-            <object width="0.487" X="1.204" Y="1.356" height="0.100" type="RectObject" angle="0.000">
-                <property key="Bounciness">0.1</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">0.1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
-            <object width="0.500" X="2.020" Y="1.350" height="0.100" type="RectObject" angle="0.000">
-                <property key="Bounciness">0.1</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">0.1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
-            <object width="0.250" X="2.875" Y="1.350" height="0.100" type="RectObject" angle="0.000">
-                <property key="Bounciness">0.1</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">0.1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
-            <object width="0.250" X="3.125" Y="1.350" height="0.100" type="RectObject" angle="0.000">
-                <property key="Bounciness">0.1</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">0.1</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
+            <object width="0.487" X="1.204" Y="1.356" height="0.100" type="Styrofoam" angle="0.000"/>
+            <object width="0.500" X="2.020" Y="1.350" height="0.100" type="Styrofoam" angle="0.000"/>
+            <object width="0.250" X="2.875" Y="1.350" height="0.100" type="Styrofoam" angle="0.000"/>
+            <object width="0.250" X="3.125" Y="1.350" height="0.100" type="Styrofoam" angle="0.000"/>
             <object width="0.600" X="1.500" Y="1.100" height="0.100" type="Floor" angle="1.570"/>
             <object width="0.430" X="0.758" Y="0.973" height="0.320" type="Dynamite" ID="555-1234" angle="0.000"/>
             <object width="0.430" X="1.805" Y="0.969" height="0.320" type="Dynamite" ID="555-5678" angle="0.000"/>

--- a/levels/needs-polish/find-the-message.v2.xml
+++ b/levels/needs-polish/find-the-message.v2.xml
@@ -40,29 +40,19 @@
             <object width="0.658" X="0.365" Y="2.537" height="0.100" type="Floor" angle="0.000"/>
             <object width="4.952" X="3.094" Y="2.000" height="0.100" type="Floor" angle="0.000"/>
             <object width="2.000" X="4.570" Y="1.990" height="0.080" type="Floor" angle="-0.01"/>
-            <object width="2.000" X="2.100" Y="2.250" height="0.380" type="RectObject" ID="styro-top" angle="0.000">
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1.5</property>
+            <object width="2.000" X="2.100" Y="2.250" height="0.380" type="Styrofoam" ID="styro-top" angle="0.000">
                 <property key="TranslationGuide">0</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
             </object>
             <object width="1.715" X="0.945" Y="1.500" height="0.100" type="Floor" angle="0.000"/>
             <object width="3.507" X="3.455" Y="1.500" height="0.100" type="Floor" angle="0.000"/>
             <object width="2.000" X="4.300" Y="1.490" height="0.080" type="Floor" angle="-0.01"/>
-            <object width="2.000" X="2.100" Y="1.750" height="0.380" type="RectObject" ID="styro-mid" angle="0.000">
-                <property key="Friction">0.1</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1.5</property>
+            <object width="2.000" X="2.100" Y="1.750" height="0.380" type="Styrofoam" ID="styro-mid" angle="0.000">
                 <property key="TranslationGuide">0</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
             </object>
             <object width="5.447" X="2.811" Y="1.000" height="0.100" type="Floor" angle="0.000"/>
-            <object width="2.000" X="2.100" Y="1.250" height="0.380" type="RectObject" ID="styro-bot" angle="0.000">
-                <property key="Friction">0.05</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">1.5</property>
+            <object width="2.000" X="2.100" Y="1.250" height="0.380" type="Styrofoam" ID="styro-bot" angle="0.000">
                 <property key="TranslationGuide">0</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
+                <property key="Friction">0.05</property>
             </object>
             <object width="0.220" X="4.311" Y="2.824" height="0.220" type="PostIt" angle="0.000">
                 <property key="page1">It’s almost time&lt;br>for goodbyes.</property>

--- a/levels/needs-polish/imperfectbalance.xml
+++ b/levels/needs-polish/imperfectbalance.xml
@@ -11,13 +11,8 @@
         <toolboxitem count="1">
             <object type="BowlingBall"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Right styrofoam wedge">
-            <object width="0.6" height="0.3" type="RightWedge">
-                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
-                <property key="ImageName">styrofoam-right</property>
-                <property key="Bounciness">0.1</property>
-                <property key="Mass">0.3</property>
-            </object>
+        <toolboxitem count="1">
+            <object width="0.6" height="0.3" type="RightWedge"/>
         </toolboxitem>
     </toolbox>
     <scene>

--- a/levels/needs-polish/imperfectbalance.xml
+++ b/levels/needs-polish/imperfectbalance.xml
@@ -45,18 +45,8 @@
             <object width="3.2" X="2.1" Y="0.5" height="0.1" type="Floor" angle="0">
                 <property key="Bounciness">0.0</property>
             </object>
-            <object width="0.15" X="3.9" Y="0.3" height="0.4" type="RectObject" angle="0">
-                <property key="Bounciness">0.6</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">0.3</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
-            <object width="0.15" X="3.88" Y="0.7" height="0.4" type="RectObject" angle="0">
-                <property key="Bounciness">0.6</property>
-                <property key="ImageName">styrofoam</property>
-                <property key="Mass">0.3</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-            </object>
+            <object width="0.15" X="3.9" Y="0.3" height="0.4" type="Styrofoam" angle="0"/>
+            <object width="0.15" X="3.88" Y="0.7" height="0.4" type="Styrofoam" angle="0"/>
             <object width="0.15" X="2.5" Y="0.9399999999999999" height="0.2280269058295964" type="Butterfly" ID="Butterfly" angle="0">
                 <property key="Object">Flower</property>
             </object>

--- a/levels/needs-polish/save-the-butterfly.xml
+++ b/levels/needs-polish/save-the-butterfly.xml
@@ -48,13 +48,11 @@
                 <property key="Friction">0.9</property>
             </object>
             <object width="0.22" X="0.19" Y="3.382929022271148" height="0.22" type="BowlingBall" angle="0"/>
-            <object width="0.15" X="3.8" Y="0.45" height="0.7" type="RectObject" ID="Styro" angle="0">
+            <object width="0.15" X="3.8" Y="0.45" height="0.7" type="Styrofoam" ID="Styro" angle="0">
                 <property key="Bounciness">0.7</property>
                 <property key="Friction">0.02</property>
-                <property key="ImageName">styrofoam</property>
                 <property key="Mass">0.026</property>
                 <property key="TranslationGuide">1.57</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
             </object>
             <object width="0.27" X="3.48" Y="1.84" height="0.36" type="Balloon" ID="Balloon1" angle="0.18">
                 <property key="ImageName">BalloonRed;BalloonPoof;BalloonRestRed;Empty</property>

--- a/levels/needs-polish/styrofoam.xml
+++ b/levels/needs-polish/styrofoam.xml
@@ -8,13 +8,9 @@
         <date>12/20/09</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="2" name="Styrofoam Block">
-            <object width="1.0" height="0.5" type="RectObject">
-                <tooltip>Resizable styrofoam blocks... What an invention!</tooltip>
-                <property key="ImageName">styrofoam</property>
-                <property key="Bounciness">0.6</property>
+        <toolboxitem count="2">
+            <object width="1.0" height="0.5" type="Styrofoam">
                 <property key="Resizable">totalresize</property>
-                <property key="Mass">1.0</property>
             </object>
         </toolboxitem>
     </toolbox>
@@ -46,11 +42,7 @@
                 <property key="ImageName">styrofoam-left</property>
                 <property key="Mass">0.6</property>
             </object>
-            <object width="1.000" X="3.900" Y="1.150" height="0.300" type="RectObject" angle="0.000">
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-                <property key="Bounciness">0.6</property>
-                <property key="ImageName">styrofoam</property>
-            </object>
+            <object width="1.000" X="3.900" Y="1.150" height="0.300" type="Styrofoam" angle="0.000"/>
             <object width="3.800" X="2.500" Y="0.950" height="0.100" type="Floor" angle="0.000"/>
             <object width="0.400" X="0.800" Y="1.150" height="0.250" type="LeftWedge" angle="0.000">
                 <tooltip>A light movable wedge made out of styrofoam.</tooltip>
@@ -69,11 +61,7 @@
                 <property key="ImageName">styrofoam-right</property>
                 <property key="Mass">0.6</property>
             </object>
-            <object width="1.000" X="0.600" Y="0.250" height="0.300" type="RectObject" angle="0.000">
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
-                <property key="Bounciness">0.5</property>
-                <property key="ImageName">styrofoam</property>
-            </object>
+            <object width="1.000" X="0.600" Y="0.250" height="0.300" type="Styrofoam" angle="0.000"/>
             <object width="0.400" X="3.400" Y="0.250" height="0.250" type="RightWedge" angle="0.000">
                 <tooltip>A light movable wedge made out of styrofoam.</tooltip>
                 <property key="Bounciness">0.6</property>

--- a/levels/needs-polish/styrofoam.xml
+++ b/levels/needs-polish/styrofoam.xml
@@ -36,38 +36,18 @@
                 <property key="ImageName">styrofoam-right</property>
             </object>
             <object width="3.800" X="2.000" Y="1.750" height="0.100" type="Floor" angle="0.000"/>
-            <object width="0.600" X="4.100" Y="1.500" height="0.400" type="LeftWedge" angle="0.000">
-                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
-                <property key="Bounciness">0.6</property>
-                <property key="ImageName">styrofoam-left</property>
-                <property key="Mass">0.6</property>
-            </object>
+            <object width="0.600" X="4.100" Y="1.500" height="0.400" type="LeftStyrofoamWedge" angle="0.000"/>
             <object width="1.000" X="3.900" Y="1.150" height="0.300" type="Styrofoam" angle="0.000"/>
             <object width="3.800" X="2.500" Y="0.950" height="0.100" type="Floor" angle="0.000"/>
-            <object width="0.400" X="0.800" Y="1.150" height="0.250" type="LeftWedge" angle="0.000">
-                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
-                <property key="Bounciness">0.5</property>
-                <property key="ImageName">styrofoam-left</property>
-                <property key="Mass">0.9</property>
-            </object>
+            <object width="0.400" X="0.800" Y="1.150" height="0.250" type="LeftStyrofoamWedge" angle="0.000"/>
             <object width="0.400" X="0.300" Y="1.550" height="0.300" type="LeftFixedWedge" angle="3.140">
                 <tooltip>This styrofoam wedge has been glued to the wall.</tooltip>
                 <property key="Bounciness">0.6</property>
                 <property key="ImageName">styrofoam-left</property>
             </object>
-            <object width="0.600" X="0.400" Y="0.700" height="0.400" type="RightWedge" angle="0.000">
-                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
-                <property key="Bounciness">0.6</property>
-                <property key="ImageName">styrofoam-right</property>
-                <property key="Mass">0.6</property>
-            </object>
+            <object width="0.600" X="0.400" Y="0.700" height="0.400" type="RightStyrofoamWedge" angle="0.000"/>
             <object width="1.000" X="0.600" Y="0.250" height="0.300" type="Styrofoam" angle="0.000"/>
-            <object width="0.400" X="3.400" Y="0.250" height="0.250" type="RightWedge" angle="0.000">
-                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
-                <property key="Bounciness">0.6</property>
-                <property key="ImageName">styrofoam-right</property>
-                <property key="Mass">0.9</property>
-            </object>
+            <object width="0.400" X="3.400" Y="0.250" height="0.250" type="RightStyrofoamWedge" angle="0.000"/>
             <object width="0.120" X="3.900" Y="0.260" height="0.340" type="BowlingPin" ID="thepin" angle="0.000">
                 <property key="Mass">0.5</property>
             </object>

--- a/levels/needs-polish/zoingandboom.xml
+++ b/levels/needs-polish/zoingandboom.xml
@@ -53,12 +53,10 @@
             <object ID="Balloon3" X="3.77" Y="2" width="0.27" angle="0" type="Balloon" height="0.36"/>
             <object ID="Balloon4" X="4.04" Y="2" width="0.27" angle="0" type="Balloon" height="0.36"/>
             <object ID="Balloon5" X="4.31" Y="2" width="0.27" angle="0" type="Balloon" height="0.36"/>
-            <object ID="Styro" X="3.77" Y="1.4" width="0.15" angle="0" type="RectObject" height="0.4">
+            <object ID="Styro" X="3.77" Y="1.4" width="0.15" angle="0" type="Styrofoam" height="0.4">
                 <property key="Bounciness">0.7</property>
                 <property key="Friction">0.02</property>
-                <property key="ImageName">styrofoam</property>
                 <property key="Mass">0.020</property>
-                <tooltip>Styrofoam blocks are light and durable.</tooltip>
             </object>
             <object X="3.5" Y="1.7" width="0.655" angle="0" type="Link" height="0.218">
                 <property key="ImageName">#8080FF</property>

--- a/levels/test/test-objects.xml
+++ b/levels/test/test-objects.xml
@@ -9,7 +9,7 @@
     </levelinfo>
     <toolbox/>
     <scene>
-        <scenesize width="9" height="5"/>
+        <scenesize width="10" height="5"/>
         <predefined>
             <object X="7.25743" Y="2.93705" width="0.27" angle="0" type="Balloon" height="0.36"/>
             <object X="1.57174" Y="2.96067" width="0.8" angle="0" type="BedOfNails" height="0.15"/>
@@ -57,7 +57,9 @@
             <object X="4.8026" Y="3.29594" width="1" angle="0" type="RectObject" height="1"/>
             <object X="4.70639" Y="4.43908" width="1" angle="0" type="PolyObject" height="1"/>
             <object X="7.96605" Y="3.62417" width="1" angle="0" type="Scenery" height="1"/>
-            <object X="5.09385" Y="0.387692" width="0.12" angle="0" type="BowlingPin" height="0.34"/>
+            <object X="8.987" Y="3.888" type="Styrofoam" />
+            <object X="9.244" Y="2.801" type="RightStyrofoamWedge" />
+            <object X="9.244" Y="0.9" type="LeftStyrofoamWedge" />
         </predefined>
         <background>
             <gradientstop pos="0">0.8;0.8;1;1</gradientstop>

--- a/levels/test/test-toolbox.xml
+++ b/levels/test/test-toolbox.xml
@@ -29,6 +29,7 @@
         <toolboxitem count="1"><object type="IBeam"/></toolboxitem>
         <toolboxitem count="1"><object type="LeftFixedWedge"/></toolboxitem>
         <toolboxitem count="1"><object type="LeftRamp"/></toolboxitem>
+        <toolboxitem count="1"><object type="LeftStyrofoamWedge"/></toolboxitem>
         <toolboxitem count="1"><object type="LeftWedge"/></toolboxitem>
         <toolboxitem count="1"><object type="PetanqueBoule"/></toolboxitem>
         <toolboxitem count="1"><object type="PingusSleeping"/></toolboxitem>
@@ -39,12 +40,14 @@
         <toolboxitem count="1"><object type="QuarterArc80"/></toolboxitem>
         <toolboxitem count="1"><object type="RightFixedWedge"/></toolboxitem>
         <toolboxitem count="1"><object type="RightRamp"/></toolboxitem>
+        <toolboxitem count="1"><object type="RightStyrofoamWedge"/></toolboxitem>
         <toolboxitem count="1"><object type="RightWedge"/></toolboxitem>
         <toolboxitem count="1"><object type="RotatingBar"/></toolboxitem>
         <toolboxitem count="1"><object type="SeesawSmall"/></toolboxitem>
         <toolboxitem count="1"><object type="Skyhook"/></toolboxitem>
         <toolboxitem count="1"><object type="SoccerBall"/></toolboxitem>
         <toolboxitem count="1"><object type="Spring"/></toolboxitem>
+        <toolboxitem count="1"><object type="Styrofoam"/></toolboxitem>
         <toolboxitem count="1"><object type="TennisBall"/></toolboxitem>
         <toolboxitem count="1"><object type="ToyChest"/></toolboxitem>
         <toolboxitem count="1"><object type="VolleyBall"/></toolboxitem>

--- a/src/model/PolyObject.cpp
+++ b/src/model/PolyObject.cpp
@@ -114,6 +114,24 @@ static AbstractPolyObjectFactory theRightWedgeFactory(
     "(-0.5,0.5)=(-0.5,-0.5)=(0.5,-0.5)=(0.5,-0.46)",
     1.0, 1.0, 2.0, 0.2 );
 
+static AbstractPolyObjectFactory theLeftStyrofoamWedgeFactory(
+    "LeftStyrofoamWedge",
+    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Left Styrofoam Wedge"),
+    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
+                      "Styrofoam wedges are light and bouncy."),
+    "styrofoam-left",
+    "(-0.5,-0.46)=(-0.5,-0.5)=(0.5,-0.5)=(0.5,0.5)",
+    1.0, 1.0, 0.5, 0.6 );
+
+static AbstractPolyObjectFactory theRightStyrofoamWedgeFactory(
+    "RightStyrofoamWedge",
+    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Right Styrofoam Wedge"),
+    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
+                      "Styrofoam wedges are light and bouncy."),
+    "styrofoam-right",
+    "(-0.5,0.5)=(-0.5,-0.5)=(0.5,-0.5)=(0.5,-0.46)",
+    1.0, 1.0, 0.5, 0.6 );
+
 static AbstractPolyObjectFactory theLeftFixedWedgeFactory(
     "LeftFixedWedge",
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Left Fixed Wedge"),

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -59,11 +59,11 @@ static AbstractRectObjectFactory theBirchBarFactory("BirchBar",
                                                                       "Birch is a type of wood.\nBirch wood beams move and float."),
                                                     "birch_bar", 1.0, 0.1, 7.2, 0.15 );
 
-static AbstractRectObjectFactory theFloorFactory("Styrofoam",
+static AbstractRectObjectFactory theStyrofoamFactory("Styrofoam",
                                                  QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Styrofoam Block"),
                                                  QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
                                                                    "Styrofoam blocks are light and durable."),
-                                                 "styrofoam", 0.5, 0.25, 0.9, 0.6 );
+                                                 "styrofoam", 0.5, 0.25, 0.5, 0.6 );
 
 static AbstractRectObjectFactory theDomRedFactory("DominoRed",
                                                   QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Red)"),

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -62,7 +62,7 @@ static AbstractRectObjectFactory theBirchBarFactory("BirchBar",
 static AbstractRectObjectFactory theStyrofoamFactory("Styrofoam",
                                                  QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Styrofoam Block"),
                                                  QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
-                                                                   "Styrofoam blocks are light and durable."),
+                                                                   "Styrofoam blocks are light and bouncy."),
                                                  "styrofoam", 0.5, 0.25, 0.5, 0.6 );
 
 static AbstractRectObjectFactory theDomRedFactory("DominoRed",

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -59,6 +59,12 @@ static AbstractRectObjectFactory theBirchBarFactory("BirchBar",
                                                                       "Birch is a type of wood.\nBirch wood beams move and float."),
                                                     "birch_bar", 1.0, 0.1, 7.2, 0.15 );
 
+static AbstractRectObjectFactory theFloorFactory("Styrofoam",
+                                                 QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Styrofoam Block"),
+                                                 QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
+                                                                   "Styrofoam blocks are light and durable."),
+                                                 "styrofoam", 0.5, 0.25, 0.9, 0.6 );
+
 static AbstractRectObjectFactory theDomRedFactory("DominoRed",
                                                   QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Red)"),
                                                   QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous red plastic domino stone."),


### PR DESCRIPTION
This PR does a part of #123.
Styrofoam is fairly common, so I turned them into default objects.
This adds a styofoam block and two styrofoam wedges (left and right).

Styrofoam has low mass and high bounciness.

I have replaced most wedges and RectObjects in existing levels with the new styrofoam objects, I also adjusted physical properties (if possible) to have more “unified” styrofoam stuff. I preserved properties when the level would break otherwise. All modified levels were tested again.

The “fixed” styrofoam wedges seen in a few levels (i.e. `styrofoam.xml`) is kept since they are a somewhat special case.