### PR TITLE
Add 2 crate objects

### DIFF
--- a/levels/finished/birds1.xml
+++ b/levels/finished/birds1.xml
@@ -23,36 +23,36 @@
     <scene>
         <scenesize width="10" height="6.5"/>
         <predefined>
-            <object width="0.800" X="6.799" Y="1.567" height="0.340" type="WoodCrateLight" angle="1.571">
+            <object width="0.800" X="6.799" Y="1.567" height="0.340" type="WoodCrateFlat" angle="1.571">
                 <property key="Mass">1</property>
             </object>
-            <object width="0.800" X="9.200" Y="2.020" height="0.340" type="WoodCrateLight" angle="0.000">
+            <object width="0.800" X="9.200" Y="2.020" height="0.340" type="WoodCrateFlat" angle="0.000">
                 <property key="Mass">1</property>
             </object>
-            <object width="0.800" X="7.178" Y="1.582" height="0.340" type="WoodCrateLight" angle="1.571">
+            <object width="0.800" X="7.178" Y="1.582" height="0.340" type="WoodCrateFlat" angle="1.571">
                 <property key="Mass">1</property>
             </object>
-            <object width="0.800" X="8.990" Y="0.970" height="0.340" type="WoodCrateLight" angle="0.000">
+            <object width="0.800" X="8.990" Y="0.970" height="0.340" type="WoodCrateFlat" angle="0.000">
                 <property key="Mass">1</property>
             </object>
-            <object width="0.800" X="7.144" Y="0.282" height="0.340" type="WoodCrateLight" angle="0.000">
+            <object width="0.800" X="7.144" Y="0.282" height="0.340" type="WoodCrateFlat" angle="0.000">
                 <property key="Mass">1</property>
             </object>
-            <object width="0.800" X="1.100" Y="0.170" height="0.340" type="WoodCrateLight" angle="0.000">
+            <object width="0.800" X="1.100" Y="0.170" height="0.340" type="WoodCrateFlat" angle="0.000">
                 <property key="Mass">0</property>
             </object>
-            <object width="0.700" X="8.550" Y="1.500" height="0.700" type="WoodCrateHeavy" angle="0.000">
+            <object width="0.700" X="8.550" Y="1.500" height="0.700" type="WoodCrateSquare" angle="0.000">
                 <property key="Mass">5</property>
             </object>
-            <object width="0.700" X="7.088" Y="0.817" height="0.700" type="WoodCrateHeavy" angle="0.000">
+            <object width="0.700" X="7.088" Y="0.817" height="0.700" type="WoodCrateSquare" angle="0.000">
                 <property key="Mass">3</property>
                 <tooltip>A wooden crate of medium weight, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="9.402" Y="1.500" height="0.700" type="WoodCrateHeavy" angle="3.140">
+            <object width="0.700" X="9.402" Y="1.500" height="0.700" type="WoodCrateSquare" angle="3.140">
                 <property key="Mass">3</property>
                 <tooltip>A wooden crate of medium weight, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="9.050" Y="0.450" height="0.700" type="WoodCrateHeavy" angle="0.000">
+            <object width="0.700" X="9.050" Y="0.450" height="0.700" type="WoodCrateSquare" angle="0.000">
                 <property key="Mass">3</property>
                 <tooltip>A wooden crate of medium weight, great for stacking.</tooltip>
             </object>

--- a/levels/finished/birds1.xml
+++ b/levels/finished/birds1.xml
@@ -23,53 +23,36 @@
     <scene>
         <scenesize width="10" height="6.5"/>
         <predefined>
-            <object width="0.800" X="6.799" Y="1.567" height="0.340" type="RectObject" angle="1.571">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.800" X="6.799" Y="1.567" height="0.340" type="WoodCrateLight" angle="1.571">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.800" X="9.200" Y="2.020" height="0.340" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.800" X="9.200" Y="2.020" height="0.340" type="WoodCrateLight" angle="0.000">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.800" X="7.178" Y="1.582" height="0.340" type="RectObject" angle="1.571">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.800" X="7.178" Y="1.582" height="0.340" type="WoodCrateLight" angle="1.571">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.800" X="8.990" Y="0.970" height="0.340" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.800" X="8.990" Y="0.970" height="0.340" type="WoodCrateLight" angle="0.000">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.800" X="7.144" Y="0.282" height="0.340" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.800" X="7.144" Y="0.282" height="0.340" type="WoodCrateLight" angle="0.000">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.800" X="1.100" Y="0.170" height="0.340" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.800" X="1.100" Y="0.170" height="0.340" type="WoodCrateLight" angle="0.000">
                 <property key="Mass">0</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="8.550" Y="1.500" height="0.700" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_square</property>
+            <object width="0.700" X="8.550" Y="1.500" height="0.700" type="WoodCrateHeavy" angle="0.000">
                 <property key="Mass">5</property>
-                <tooltip>A heavy wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="7.088" Y="0.817" height="0.700" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_square</property>
+            <object width="0.700" X="7.088" Y="0.817" height="0.700" type="WoodCrateHeavy" angle="0.000">
                 <property key="Mass">3</property>
                 <tooltip>A wooden crate of medium weight, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="9.402" Y="1.500" height="0.700" type="RectObject" angle="3.140">
-                <property key="ImageName">wood_crate_square</property>
+            <object width="0.700" X="9.402" Y="1.500" height="0.700" type="WoodCrateHeavy" angle="3.140">
                 <property key="Mass">3</property>
                 <tooltip>A wooden crate of medium weight, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="9.050" Y="0.450" height="0.700" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_square</property>
+            <object width="0.700" X="9.050" Y="0.450" height="0.700" type="WoodCrateHeavy" angle="0.000">
                 <property key="Mass">3</property>
                 <tooltip>A wooden crate of medium weight, great for stacking.</tooltip>
             </object>

--- a/levels/finished/birds2.xml
+++ b/levels/finished/birds2.xml
@@ -20,55 +20,38 @@
     <scene>
         <scenesize width="10" height="6.5"/>
         <predefined>
-            <object width="0.720" X="6.800" Y="1.530" height="0.340" type="RectObject" angle="1.570">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.720" X="6.800" Y="1.530" height="0.340" type="WoodCrateLight" angle="1.570">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.800" X="9.210" Y="2.010" height="0.340" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.800" X="9.210" Y="2.010" height="0.340" type="WoodCrateLight" angle="0.000">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.720" X="7.180" Y="1.530" height="0.340" type="RectObject" angle="1.570">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.720" X="7.180" Y="1.530" height="0.340" type="WoodCrateLight" angle="1.570">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.800" X="8.780" Y="0.980" height="0.340" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.800" X="8.780" Y="0.980" height="0.340" type="WoodCrateLight" angle="0.000">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
             <object width="0.800" X="7.060" Y="0.270" height="0.360" type="Floor" angle="0.000"/>
-            <object width="0.800" X="7.080" Y="2.040" height="0.300" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.800" X="7.080" Y="2.040" height="0.300" type="WoodCrateLight" angle="0.000">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.800" X="8.380" Y="2.010" height="0.340" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_flat</property>
+            <object width="0.800" X="8.380" Y="2.010" height="0.340" type="WoodCrateLight" angle="0.000">
                 <property key="Mass">1</property>
-                <tooltip>A light wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="8.640" Y="1.500" height="0.700" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_square</property>
+            <object width="0.700" X="8.640" Y="1.500" height="0.700" type="WoodCrateHeavy" angle="0.000">
                 <property key="Mass">5</property>
-                <tooltip>A heavy wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="7.088" Y="0.817" height="0.700" type="RectObject" angle="0.000">
-                <property key="ImageName">wood_crate_square</property>
+            <object width="0.700" X="7.088" Y="0.817" height="0.700" type="WoodCrateHeavy" angle="0.000">
                 <property key="Mass">3</property>
                 <tooltip>A wooden crate of medium weight, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="9.410" Y="1.490" height="0.700" type="RectObject" angle="3.140">
-                <property key="ImageName">wood_crate_square</property>
+            <object width="0.700" X="9.410" Y="1.490" height="0.700" type="WoodCrateHeavy" angle="3.140">
                 <property key="Mass">6</property>
                 <tooltip>A pretty heavy wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="8.810" Y="0.450" height="0.700" type="RectObject" angle="0.000">
+            <object width="0.700" X="8.810" Y="0.450" height="0.700" type="WoodCrateHeavy" angle="0.000">
                 <property key="Friction">1</property>
-                <property key="ImageName">wood_crate_square</property>
                 <property key="Mass">3</property>
                 <tooltip>A wooden crate of medium weight, great for stacking.</tooltip>
             </object>

--- a/levels/finished/birds2.xml
+++ b/levels/finished/birds2.xml
@@ -20,37 +20,37 @@
     <scene>
         <scenesize width="10" height="6.5"/>
         <predefined>
-            <object width="0.720" X="6.800" Y="1.530" height="0.340" type="WoodCrateLight" angle="1.570">
+            <object width="0.720" X="6.800" Y="1.530" height="0.340" type="WoodCrateFlat" angle="1.570">
                 <property key="Mass">1</property>
             </object>
-            <object width="0.800" X="9.210" Y="2.010" height="0.340" type="WoodCrateLight" angle="0.000">
+            <object width="0.800" X="9.210" Y="2.010" height="0.340" type="WoodCrateFlat" angle="0.000">
                 <property key="Mass">1</property>
             </object>
-            <object width="0.720" X="7.180" Y="1.530" height="0.340" type="WoodCrateLight" angle="1.570">
+            <object width="0.720" X="7.180" Y="1.530" height="0.340" type="WoodCrateFlat" angle="1.570">
                 <property key="Mass">1</property>
             </object>
-            <object width="0.800" X="8.780" Y="0.980" height="0.340" type="WoodCrateLight" angle="0.000">
+            <object width="0.800" X="8.780" Y="0.980" height="0.340" type="WoodCrateFlat" angle="0.000">
                 <property key="Mass">1</property>
             </object>
             <object width="0.800" X="7.060" Y="0.270" height="0.360" type="Floor" angle="0.000"/>
-            <object width="0.800" X="7.080" Y="2.040" height="0.300" type="WoodCrateLight" angle="0.000">
+            <object width="0.800" X="7.080" Y="2.040" height="0.300" type="WoodCrateFlat" angle="0.000">
                 <property key="Mass">1</property>
             </object>
-            <object width="0.800" X="8.380" Y="2.010" height="0.340" type="WoodCrateLight" angle="0.000">
+            <object width="0.800" X="8.380" Y="2.010" height="0.340" type="WoodCrateFlat" angle="0.000">
                 <property key="Mass">1</property>
             </object>
-            <object width="0.700" X="8.640" Y="1.500" height="0.700" type="WoodCrateHeavy" angle="0.000">
+            <object width="0.700" X="8.640" Y="1.500" height="0.700" type="WoodCrateSquare" angle="0.000">
                 <property key="Mass">5</property>
             </object>
-            <object width="0.700" X="7.088" Y="0.817" height="0.700" type="WoodCrateHeavy" angle="0.000">
+            <object width="0.700" X="7.088" Y="0.817" height="0.700" type="WoodCrateSquare" angle="0.000">
                 <property key="Mass">3</property>
                 <tooltip>A wooden crate of medium weight, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="9.410" Y="1.490" height="0.700" type="WoodCrateHeavy" angle="3.140">
+            <object width="0.700" X="9.410" Y="1.490" height="0.700" type="WoodCrateSquare" angle="3.140">
                 <property key="Mass">6</property>
                 <tooltip>A pretty heavy wooden crate, great for stacking.</tooltip>
             </object>
-            <object width="0.700" X="8.810" Y="0.450" height="0.700" type="WoodCrateHeavy" angle="0.000">
+            <object width="0.700" X="8.810" Y="0.450" height="0.700" type="WoodCrateSquare" angle="0.000">
                 <property key="Friction">1</property>
                 <property key="Mass">3</property>
                 <tooltip>A wooden crate of medium weight, great for stacking.</tooltip>

--- a/levels/finished/pingus-1.xml
+++ b/levels/finished/pingus-1.xml
@@ -8,8 +8,8 @@
         <date>January 3, 2016</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="2" name="Heavy Crate">
-            <object type="RectObject" width="0.600" height="0.370" angle="0.000" X="0.000" Y="0.000">
+        <toolboxitem count="2" name="Heavy Wooden Crate">
+            <object type="WoodCrateLight" width="0.600" height="0.370" angle="0.000" X="0.000" Y="0.000">
                 <property key="ImageName">wood_crate_flat</property>
                 <tooltip>A pretty heavy wooden crate, great for stacking.</tooltip>
                 <property key="Mass">50</property>

--- a/levels/finished/pingus-1.xml
+++ b/levels/finished/pingus-1.xml
@@ -8,8 +8,8 @@
         <date>January 3, 2016</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="2" name="Heavy Wooden Crate">
-            <object type="WoodCrateLight" width="0.600" height="0.370" angle="0.000" X="0.000" Y="0.000">
+        <toolboxitem count="2">
+            <object type="WoodCrateFlat" width="0.600" height="0.370" angle="0.000" X="0.000" Y="0.000">
                 <property key="ImageName">wood_crate_flat</property>
                 <tooltip>A pretty heavy wooden crate, great for stacking.</tooltip>
                 <property key="Mass">50</property>

--- a/levels/test/test-objects.xml
+++ b/levels/test/test-objects.xml
@@ -54,11 +54,14 @@
             <object X="5.50356" Y="1.31001" width="0.4" angle="0" type="Weight" height="0.4"/>
             <object X="0.5599" Y="1.29607" width="1" angle="0" type="RightRamp" height="1"/>
             <object X="0.16012" Y="2.86385" width="0.2" angle="0" type="CustomBall" height="0.2"/>
-            <object X="0.16012" Y="2.615" width="0.14" angle="0" type="Peg" height="0.14"/>
+            <object X="0.16012" Y="2.615" width="0.14" angle="0" type="PegMetal" height="0.14"/>
+            <object X="0.846" Y="2.882" width="0.14" angle="0" type="PegWood" height="0.14"/>
             <object X="4.8026" Y="3.29594" width="1" angle="0" type="RectObject" height="1"/>
             <object X="4.70639" Y="4.43908" width="1" angle="0" type="PolyObject" height="1"/>
             <object X="7.96605" Y="3.62417" width="1" angle="0" type="Scenery" height="1"/>
             <object X="5.09385" Y="0.387692" width="0.12" angle="0" type="BowlingPin" height="0.34"/>
+            <object X="2.417" Y="3.268" type="WoodCrateSquare"/>
+            <object X="2.417" Y="2.531" type="WoodCrateFlat"/>
         </predefined>
         <background>
             <gradientstop pos="0">0.8;0.8;1;1</gradientstop>

--- a/levels/test/test-toolbox.xml
+++ b/levels/test/test-toolbox.xml
@@ -30,7 +30,8 @@
         <toolboxitem count="1"><object type="LeftFixedWedge"/></toolboxitem>
         <toolboxitem count="1"><object type="LeftRamp"/></toolboxitem>
         <toolboxitem count="1"><object type="LeftWedge"/></toolboxitem>
-        <toolboxitem count="1"><object type="Peg"/></toolboxitem>
+        <toolboxitem count="1"><object type="PegMetal"/></toolboxitem>
+        <toolboxitem count="1"><object type="PegWood"/></toolboxitem>
         <toolboxitem count="1"><object type="PetanqueBoule"/></toolboxitem>
         <toolboxitem count="1"><object type="PingusSleeping"/></toolboxitem>
         <toolboxitem count="1"><object type="PingusWalkLeft"/></toolboxitem>
@@ -51,6 +52,8 @@
         <toolboxitem count="1"><object type="VolleyBall"/></toolboxitem>
         <toolboxitem count="1"><object type="Wall"/></toolboxitem>
         <toolboxitem count="1"><object type="Weight"/></toolboxitem>
+        <toolboxitem count="1"><object type="WoodCrateFlat"/></toolboxitem>
+        <toolboxitem count="1"><object type="WoodCrateSquare"/></toolboxitem>
     </toolbox>
     <scene>
         <scenesize width="8.5" height="5"/>

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -109,6 +109,18 @@ static AbstractRectObjectFactory theColaCrateFactory("ColaCrate",
                                                      "cola-crate", 0.85, 0.6, 18.0, 0.1,
                                                      "Friction:0.1/");
 
+static AbstractRectObjectFactory theLightWoodCrateFactory("WoodCrateLight",
+                                                     QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Light Wooden Crate"),
+                                                     QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
+                                                                       "A light wooden crate, great for stacking."),
+                                                     "wood_crate_flat", 0.8, 0.34, 3.0, 0.1);
+
+static AbstractRectObjectFactory theHeavyWoodCrateFactory("WoodCrateHeavy",
+                                                     QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Heavy Wooden Crate"),
+                                                     QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
+                                                                       "A heavy wooden crate, great for stacking."),
+                                                     "wood_crate_square", 0.7, 0.7, 6.0, 0.1);
+
 // Constructors/Destructors
 //
 

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -109,14 +109,14 @@ static AbstractRectObjectFactory theColaCrateFactory("ColaCrate",
                                                      "cola-crate", 0.85, 0.6, 18.0, 0.1,
                                                      "Friction:0.1/");
 
-static AbstractRectObjectFactory theLightWoodCrateFactory("WoodCrateLight",
-                                                     QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Light Wooden Crate"),
+static AbstractRectObjectFactory theLightWoodCrateFactory("WoodCrateFlat",
+                                                     QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Flat Wooden Crate"),
                                                      QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
-                                                                       "A light wooden crate, great for stacking."),
+                                                                       "A flat and light wooden crate, great for stacking."),
                                                      "wood_crate_flat", 0.8, 0.34, 3.0, 0.1);
 
-static AbstractRectObjectFactory theHeavyWoodCrateFactory("WoodCrateHeavy",
-                                                     QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Heavy Wooden Crate"),
+static AbstractRectObjectFactory theHeavyWoodCrateFactory("WoodCrateSquare",
+                                                     QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Square Wooden Crate"),
                                                      QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
                                                                        "A heavy wooden crate, great for stacking."),
                                                      "wood_crate_square", 0.7, 0.7, 6.0, 0.1);


### PR DESCRIPTION
Part of fixing https://github.com/the-butterfly-effect/tbe/issues/123.

This adds 2 wooden crates, a flat one and a square one. The square one is larger and heavier.
Crates were used in 3 levels already as `RectObject`s, those have been replaced. Custom properties have been preserved.