### PR TITLE
Tweak object descriptions and names once again

### DIFF
--- a/levels/finished/10_kilograms_above_the_ground.xml
+++ b/levels/finished/10_kilograms_above_the_ground.xml
@@ -16,7 +16,7 @@
         <toolboxitem count="1">
             <object height="0.34" type="BowlingPin" width="0.12" angle="0" Y="1.44731" X="2.45699"/>
         </toolboxitem>
-        <toolboxitem name="Wood triangle" count="1">
+        <toolboxitem name="Wooden Triangle" count="1">
             <object height="0.22" type="LeftFixedWedge" width="0.22" angle="-3.91635" Y="0.987901" X="1.49779">
                 <tooltip>This piece of wood has a triangular shape with one tip pointing upwards. It doesn’t move.</tooltip>
             </object>

--- a/levels/finished/balloon_blues.xml
+++ b/levels/finished/balloon_blues.xml
@@ -27,10 +27,10 @@
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem count="1" name="Right ramp">
+        <toolboxitem count="1">
             <object width="0.93" X="4.781" Y="0.788" height="0.66" type="RightRamp" angle="0"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Wooden block">
+        <toolboxitem count="1" name="Wooden Block">
             <object width="0.107" X="1.376" Y="1.069" height="0.100" type="Floor" angle="0.000">
                 <tooltip>A small immovable obstacle.</tooltip>
             </object>

--- a/levels/finished/boom_boom_boom.xml
+++ b/levels/finished/boom_boom_boom.xml
@@ -24,10 +24,10 @@
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem count="2" name="Right ramp (large)">
+        <toolboxitem count="2" name="Large Right Ramp">
             <object type="RightRamp" angle="0" Y="5.15587" X="10.1977" height="0.705502" width="0.848975"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Right ramp (small)">
+        <toolboxitem count="1" name="Small Right Ramp">
             <object type="RightRamp" angle="0" Y="3.69093" X="10.2846" height="0.297735" width="0.448759"/>
         </toolboxitem>
         <toolboxitem count="2">

--- a/levels/finished/butterflies_of_doom.xml
+++ b/levels/finished/butterflies_of_doom.xml
@@ -19,21 +19,21 @@
         <toolboxitem count="1">
             <object width="1.000" X="0.756" Y="1.984" height="1.000" type="LeftRamp" angle="0.000"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Long left fixed wedge">
+        <toolboxitem count="1" name="Long Left Inclined Plane">
             <object width="0.575" X="2.063" Y="1.475" height="0.186" type="LeftFixedWedge" angle="0.000"/>
         </toolboxitem>
         <toolboxitem count="1">
             <object width="0.653" X="0.303" Y="1.380" height="0.696" type="RightFixedWedge" angle="0.000"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Short left fixed wedge">
+        <toolboxitem count="1" name="Short Left Inclined Plane">
             <object width="0.286" X="5.412" Y="0.341" height="0.311" type="LeftFixedWedge" angle="0.000"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Small quarter arc">
+        <toolboxitem count="1" name="Small Quarter Arc">
             <object width="0.461" X="1.080" Y="0.736" height="0.404" type="QuarterArc80">
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem count="1" name="Very small quarter arc">
+        <toolboxitem count="1" name="Very Small Quarter Arc">
             <object width="0.356" X="2.700" Y="1.707" height="0.276" type="QuarterArc80">
                 <property key="Rotatable">true</property>
             </object>

--- a/levels/finished/cola_chaos.xml
+++ b/levels/finished/cola_chaos.xml
@@ -8,10 +8,10 @@
         <date>04.02.16</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem name="Cola+mint bottle (right)" count="1">
+        <toolboxitem name="Right Cola+Mint Bottle" count="1">
             <object height="0.5" width="0.166" Y="0" X="0" type="ColaMintBottle" angle="4.72"/>
         </toolboxitem>
-        <toolboxitem name="Cola+mint bottle (left)" count="1">
+        <toolboxitem name="Left Cola+Mint Bottle" count="1">
             <object height="0.5" width="0.166" Y="0" X="0" type="ColaMintBottle" angle="1.577"/>
         </toolboxitem>
         <toolboxitem count="5">

--- a/levels/finished/contraption1.xml
+++ b/levels/finished/contraption1.xml
@@ -8,7 +8,7 @@
         <date>04/23/10</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="2" name="Right birch wedge">
+        <toolboxitem count="2">
             <object width="0.4" X="0.30" Y="0.35" height="0.3" type="RightWedge">
                 <property key="Bounciness">0.3</property>
                 <property key="Mass">2.0</property>

--- a/levels/finished/creativity.xml
+++ b/levels/finished/creativity.xml
@@ -31,7 +31,7 @@
         <toolboxitem count="1">
             <object Y="0" type="Floor" height="0.1" angle="0" width="1" X="0"/>
         </toolboxitem>
-        <toolboxitem name="Left birch wedge" count="1">
+        <toolboxitem count="1">
             <object Y="0" type="LeftWedge" height="0.5" angle="0" width="0.5" X="0"/>
         </toolboxitem>
         <toolboxitem count="1">

--- a/levels/finished/domino_chest.xml
+++ b/levels/finished/domino_chest.xml
@@ -18,10 +18,10 @@
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem name="Left fixed wedge" count="1">
+        <toolboxitem count="1">
             <object angle="0.000" type="LeftFixedWedge" X="1.266" height="0.288" Y="4.582" width="0.656"/>
         </toolboxitem>
-        <toolboxitem name="Right fixed wedge" count="1">
+        <toolboxitem count="1">
             <object angle="0.000" type="RightFixedWedge" X="0.718" height="0.311" Y="5.103" width="1.061"/>
         </toolboxitem>
         <toolboxitem count="1">

--- a/levels/finished/find-the-message.v2.xml
+++ b/levels/finished/find-the-message.v2.xml
@@ -14,7 +14,7 @@
         <toolboxitem count="1">
             <object width="0.400" X="2.399" Y="2.665" height="0.200" type="Spring" angle="0.000"/>
         </toolboxitem>
-        <toolboxitem count="2" name="Birch wedge">
+        <toolboxitem count="2" name="Birch Wedge">
             <object width="0.350" height="0.350" type="RightWedge">
                 <tooltip>This is a movable birch wedge.</tooltip>
                 <property key="Rotatable">true</property>

--- a/levels/finished/in_the_attic.xml
+++ b/levels/finished/in_the_attic.xml
@@ -8,7 +8,7 @@
         <date>06.01.16</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="1" name="Birch block">
+        <toolboxitem count="1" name="Birch Block">
             <object width="0.630" height="0.152" type="BirchBar"/>
         </toolboxitem>
         <toolboxitem count="7">

--- a/levels/finished/loopings2.xml
+++ b/levels/finished/loopings2.xml
@@ -11,7 +11,7 @@
         <toolboxitem count="2">
             <object height="0.36" width="0.27" type="Balloon" angle="0" X="0" Y="0"/>
         </toolboxitem>
-        <toolboxitem count="2" name="Birch block">
+        <toolboxitem count="2" name="Birch Block">
             <object height="0.2" width="0.28" type="BirchBar" angle="0" X="0" Y="0">
                 <property key="Mass">0.2</property>
                 <tooltip>A small movable block out of birch wood,&lt;br&gt;it’s a bit lighter than a regular birch wood beam.</tooltip>

--- a/levels/finished/picnic-3.xml
+++ b/levels/finished/picnic-3.xml
@@ -18,7 +18,7 @@
                 <property key="Thrust"> 8.0 </property>
             </object>
         </toolboxitem>
-        <toolboxitem count="1" name="Wooden block">
+        <toolboxitem count="1" name="Wooden Block">
             <object width="0.200" X="3.850" Y="0.500" height="0.200" type="Floor" angle="0.000">
                 <tooltip>A small immovable obstacle.</tooltip>
             </object>

--- a/levels/finished/pingus-introduction.xml
+++ b/levels/finished/pingus-introduction.xml
@@ -8,10 +8,10 @@
         <date>10.01.16</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="1" name="High wall">
+        <toolboxitem count="1" name="High Wall">
             <object type="Wall" width="0.138" Y="0.000" angle="0.000" X="0.000" height="1.028"/>
         </toolboxitem>
-        <toolboxitem count="2" name="Low wall">
+        <toolboxitem count="2" name="Low Wall">
             <object type="Wall" width="0.138" Y="0.000" angle="0.000" X="0.000" height="0.514"/>
         </toolboxitem>
         <toolboxitem count="1">

--- a/levels/finished/poofpoofpoof.xml
+++ b/levels/finished/poofpoofpoof.xml
@@ -11,7 +11,7 @@
         <toolboxitem count="1">
             <object width="0.380" X="0.555" Y="2.466" height="0.380" type="CircularSaw" angle="0.000"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Left birch wedge">
+        <toolboxitem count="1">
             <object width="0.400" height="0.200" type="LeftWedge">
                 <property key="Mass">0.6</property>
             </object>

--- a/levels/finished/rotate_and_win.xml
+++ b/levels/finished/rotate_and_win.xml
@@ -13,17 +13,17 @@
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem name="Large quarter arc (left)" count="1">
+        <toolboxitem name="Left Large Quarter Arc" count="1">
             <object Y="0.000" width="0.538" height="1.225" type="QuarterArc80" angle="0.000" X="0.000">
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem name="Large quarter arc (right)" count="1">
+        <toolboxitem name="Right Large Quarter Arc" count="1">
             <object Y="0.000" width="0.843" height="0.556" type="QuarterArc80" angle="0.000" X="0.000">
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem name="Small quarter arc" count="1">
+        <toolboxitem count="1">
             <object Y="0.000" width="0.379" height="0.858" type="QuarterArc40" angle="0.000" X="0.000">
                 <property key="Rotatable">true</property>
             </object>

--- a/levels/finished/the_pit.xml
+++ b/levels/finished/the_pit.xml
@@ -8,22 +8,22 @@
         <date>05.02.16</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="1" name="Rotating bar (long)">
+        <toolboxitem count="1" name="Long Rotating Bar">
             <object width="2.19345" height="0.1" Y="0" angle="-1.57" type="RotatingBar" X="0" />
         </toolboxitem>
-        <toolboxitem count="4" name="Rotating bar (short)">
+        <toolboxitem count="4" name="Short Rotating Bar">
             <object width="1.05327" height="0.1" Y="0" angle="-1.57" type="RotatingBar" X="0" />
         </toolboxitem>
         <toolboxitem count="1">
             <object width="0.166" height="0.5" Y="0" angle="-3.16517" type="ColaMintBottle" X="0"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Left fixed wedge (large)">
+        <toolboxitem count="1" name="Large Left Inclined Plane">
             <object width="1.00755" height="0.546925" Y="4.52859" angle="0" type="LeftFixedWedge" X="12.061"/>
         </toolboxitem>
-        <toolboxitem count="2" name="Left fixed wedge (medium)">
+        <toolboxitem count="2" name="Medium Left Inclined Plane">
             <object width="0.879181" height="0.350593" Y="0.632157" angle="0" type="LeftFixedWedge" X="12.5858"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Left fixed wedge (small)">
+        <toolboxitem count="1" name="Small Left Inclined Plane">
             <object width="0.660195" height="0.26753" Y="1.21144" angle="0" type="LeftFixedWedge" X="12.6138"/>
         </toolboxitem>
         <toolboxitem count="4">
@@ -31,13 +31,13 @@
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem count="1" name="Right fixed wedge (large)">
+        <toolboxitem count="1" name="Large Right Inclined Plane">
             <object width="1.0151" height="0.290184" Y="0.188241" angle="0" type="RightFixedWedge" X="12.6553"/>
         </toolboxitem>
-        <toolboxitem count="2" name="Right fixed wedge (medium)">
+        <toolboxitem count="2" name="Medium Right Inclined Plane">
             <object width="0.773462" height="0.20712" Y="0.645094" angle="0" type="RightFixedWedge" X="11.2433"/>
         </toolboxitem>
-        <toolboxitem count="3" name="Right fixed wedge (small)">
+        <toolboxitem count="3" name="Small Right Inclined Plane">
             <object width="0.56" height="0.09" Y="0" angle="0" type="RightFixedWedge" X="0"/>
         </toolboxitem>
         <toolboxitem count="1">

--- a/levels/needs-polish/butterfly_race.xml
+++ b/levels/needs-polish/butterfly_race.xml
@@ -25,23 +25,23 @@
         <toolboxitem count="1">
             <object Y="0.000" angle="0.000" type="Hammer" />
         </toolboxitem>
-        <toolboxitem name="Large quarter arc" count="2">
+        <toolboxitem count="2">
             <object Y="0.000" angle="0.000" width="0.800" type="QuarterArc80" X="0.000" height="0.800">
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem name="Large right ramp" count="1">
+        <toolboxitem name="Large Right Ramp" count="1">
             <object Y="0.000" angle="0.000" width="0.872" type="RightRamp" X="0.000" height="0.380"/>
         </toolboxitem>
         <toolboxitem count="1">
             <object Y="0.000" angle="0.000" width="0.921" type="LeftRamp" X="0.000" height="0.148"/>
         </toolboxitem>
-        <toolboxitem name="Small quarter arc" count="2">
+        <toolboxitem count="2">
             <object Y="0.000" angle="0.000" width="0.400" type="QuarterArc40" X="0.000" height="0.400">
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem name="Small right ramp" count="1">
+        <toolboxitem name="Small Right Ramp" count="1">
             <object Y="0.000" angle="0.000" width="0.514" type="RightRamp" X="0.000" height="0.431"/>
         </toolboxitem>
     </toolbox>

--- a/src/model/BalloonCactus.cpp
+++ b/src/model/BalloonCactus.cpp
@@ -346,7 +346,7 @@ static BedOfNailsObjectFactory theBedOfNailsObjectFactory;
 
 
 BedOfNails::BedOfNails()
-    : PolyObject(QObject::tr("Bed of nails"),
+    : PolyObject(QObject::tr("Bed of Nails"),
                  QObject::tr("A wooden board attached to the scene.\nIt has many sharp nails on one side."),
                  "BedOfNails",
                  // first the bar:
@@ -421,8 +421,8 @@ public:
 static CircularSawObjectFactory theCircularSawObjectFactory;
 
 CircularSaw::CircularSaw()
-    : CircleObject(QObject::tr("Circular saw"),
-                   QObject::tr("A rotating disc with sharp teeth."),
+    : CircleObject(QObject::tr("Circular Saw"),
+                   QObject::tr("A light rotating disc with sharp teeth,\ndangerous for balloons and penguins alike."),
                    "CircularSaw",
                    CIRCRADIUS, CIRCMASS, 0.1)
 {

--- a/src/model/CircleObjects.cpp
+++ b/src/model/CircleObjects.cpp
@@ -27,14 +27,13 @@
 // the non-uniform weight distribution in the ball - we assume it to be uniform
 static CircleObjectFactory theBBFactory("BowlingBall",
                                         QT_TRANSLATE_NOOP("CircleObjectFactory", "Bowling Ball"),
-                                        QT_TRANSLATE_NOOP("CircleObjectFactory",
-                                                          "Your average bowling ball: heavy, round and willing to roll."),
+                                        QT_TRANSLATE_NOOP("CircleObjectFactory", "A bowling ball is very heavy and doesn’t bounce much."),
                                         "BowlingBall", 0.11, 6.0, 0.1 );
 
 // we are lazy and do not model the air, we assume it to be uniform in mass
 static CircleObjectFactory theVBFactory("VolleyBall",
                                         QT_TRANSLATE_NOOP("CircleObjectFactory", "Volleyball"),
-                                        QT_TRANSLATE_NOOP("CircleObjectFactory", "A volleyball—you know: light, soft and very bouncy."),
+                                        QT_TRANSLATE_NOOP("CircleObjectFactory", "A volleyball is light and very bouncy."),
                                         "VolleyBall", 0.105, 0.280, 0.65);
 
 
@@ -43,7 +42,7 @@ static CircleObjectFactory theVBFactory("VolleyBall",
 // we are lazy and do not model the air, we assume it to be uniform in mass
 static CircleObjectFactory theTBFactory("TennisBall",
                                         QT_TRANSLATE_NOOP("CircleObjectFactory", "Tennis Ball"),
-                                        QT_TRANSLATE_NOOP("CircleObjectFactory", "A tennis ball is small, fuzzy and bouncy."),
+                                        QT_TRANSLATE_NOOP("CircleObjectFactory", "A tennis ball is very light and pretty bouncy."),
                                         "TennisBall", 0.034, 0.058, 0.56);
 
 // the official standards say that a soccer is 68-70cm circumference and weighs 410-450 grams
@@ -51,16 +50,15 @@ static CircleObjectFactory theTBFactory("TennisBall",
 // we are lazy and do not model the air, we assume it to be uniform in mass
 static CircleObjectFactory theSoccerFactory("SoccerBall",
                                             QT_TRANSLATE_NOOP("CircleObjectFactory", "Soccer Ball"),
-                                            QT_TRANSLATE_NOOP("CircleObjectFactory", "A soccer ball is large and bouncy."),
+                                            QT_TRANSLATE_NOOP("CircleObjectFactory", "A soccer ball is of medium weight and pretty bouncy."),
                                             "SoccerBall", 0.110, 0.430, 0.56);
 
 // there is not much of official standards for a petanque ball, but
 // thanks to http://en.wikipedia.org/wiki/Petanque we at least know:
 // diameter between 70.5 and 80mm, weight between 650 and 800 grams.
 static CircleObjectFactory thePetanqueFactory("PetanqueBoule",
-                                              QT_TRANSLATE_NOOP_UTF8("CircleObjectFactory", "Pétanque Boule"),
-                                              QT_TRANSLATE_NOOP_UTF8("CircleObjectFactory",
-                                                                     "A pétanque ball is made of metal and is quite heavy."),
+                                              QT_TRANSLATE_NOOP_UTF8("CircleObjectFactory", "Pétanque Ball"),
+                                              QT_TRANSLATE_NOOP_UTF8("CircleObjectFactory", "A pétanque ball is quite heavy and doesn’t bounce much."),
                                               "PetanqueBoule", 0.038, 0.700, 0.1);
 
 // size based on old version of picnic-2 level
@@ -74,7 +72,7 @@ static CircleObjectFactory thePegMetalFactory("PegMetal",
 static CircleObjectFactory thePegWoodFactory("PegWood",
                                          QT_TRANSLATE_NOOP("CircleObjectFactory", "Wooden Peg"),
                                          QT_TRANSLATE_NOOP("CircleObjectFactory",
-                                                           "A round obstacle, pinned to the sky.\nThings will bounce off weakly."),
+                                                           "A round obstacle, pinned to the sky.\nThings won’t bounce off much."),
                                          "wood-pin", 0.07, 0.0, 0.1);
 
 // Constructors/Destructors

--- a/src/model/Pingus.cpp
+++ b/src/model/Pingus.cpp
@@ -40,7 +40,7 @@ int Pingus::theAliveCount = 0;
 
 Pingus::Pingus(const QString &anIconName)
     : CircleObject(QObject::tr("Penguin"),
-                   QObject::tr("A penguin walks left or right and turns around when\nit collides with something heavy. It can push\nlight objects around. It also likes to slide down\nslopes but can't take much abuse."),
+                   QObject::tr("A penguin walks left or right and turns around when\nit collides with something heavy. It can push\nlight objects around. It also likes to slide down\nslopes but can’t take much abuse."),
                    "",
                    PINGUS_RADIUS, PINGUS_MASS, 0.0 ), theIconName(anIconName), theState(FALLING), theAnimationFrameIndex(0)
 {

--- a/src/model/PivotPoint.cpp
+++ b/src/model/PivotPoint.cpp
@@ -140,7 +140,7 @@ void PivotPoint::initPivotAttributes ( )
     theSecondPtr = nullptr;
     areObjectsColliding = false;
 
-    theToolTip = QObject::tr("Objects rotate around this point");
+    theToolTip = QObject::tr("Objects rotate around this point.");
     theProps.setDefaultPropertiesString(
         Property::OBJECT1_STRING + QString(":/") +
         Property::OBJECT2_STRING + QString(":/") +

--- a/src/model/PolyObject.cpp
+++ b/src/model/PolyObject.cpp
@@ -145,7 +145,7 @@ static AbstractPolyObjectFactory theRightFixedWedgeFactory(
     "RightFixedWedge",
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Right Inclined Plane"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "It’s a fixed obstacle with a tilted surface.\nThe left is higher than the right, so things slide to the right."),
+                      "It’s a fixed obstacle with a tilted surface.\nThe left is lower than the right, so things slide to the left."),
     "usedwood-wedge-right",
     "(-0.5,0.5)=(-0.5,-0.5)=(0.5,-0.5)=(0.5,-0.46)",
     1.0, 1.0, 0.0, 0.1 );

--- a/src/model/PolyObject.cpp
+++ b/src/model/PolyObject.cpp
@@ -82,7 +82,7 @@ static AbstractPolyObjectFactory theLeftRampFactory(
     "LeftRamp",
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Left Ramp"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "This is a ramp. The left is lower than the right, so things slide to the left."),
+                      "This is a ramp.\nThe left is lower than the right, so things slide to the left."),
     "LeftRamp",
     "(-0.5,-0.46)=(-0.5,-0.5)=(-0.3,-0.5)=(0.4,0.2)=(0.5,0.4)=(0.5,0.5)",
     1.0, 1.0, 0.0, 0.2 );
@@ -91,7 +91,7 @@ static AbstractPolyObjectFactory theRightRampFactory(
     "RightRamp",
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Right Ramp"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "This is a ramp. The left is higher than the right, so things slide to the right."),
+                      "This is a ramp.\nThe left is higher than the right, so things slide to the right."),
     "RightRamp",
     "(-0.5,0.5)=(-0.5,0.4)=(-0.4,0.2)=(0.3,-0.5)=(0.5,-0.5)=(0.5,-0.46)",
     1.0, 1.0, 0.0, 0.2 );
@@ -100,7 +100,7 @@ static AbstractPolyObjectFactory theLeftWedgeFactory(
     "LeftWedge",
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Left Birch Wedge"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "This is a movable birch wedge.\nThe left is lower than the right, so things slide to the left."),
+                      "Birch wedges can be moved and are rather heavy.\nThe left is lower than the right, so things slide to the left."),
     "birch-wedge-left",
     "(-0.5,-0.46)=(-0.5,-0.5)=(0.5,-0.5)=(0.5,0.5)",
     1.0, 1.0, 2.0, 0.2 );
@@ -109,7 +109,7 @@ static AbstractPolyObjectFactory theRightWedgeFactory(
     "RightWedge",
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Right Birch Wedge"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "This is a movable birch wedge.\nThe left is higher than the right, so things slide to the right."),
+                      "Birch wedges can be moved and are rather heavy.\nThe left is higher than the right, so things slide to the right."),
     "birch-wedge-right",
     "(-0.5,0.5)=(-0.5,-0.5)=(0.5,-0.5)=(0.5,-0.46)",
     1.0, 1.0, 2.0, 0.2 );
@@ -134,18 +134,18 @@ static AbstractPolyObjectFactory theRightStyrofoamWedgeFactory(
 
 static AbstractPolyObjectFactory theLeftFixedWedgeFactory(
     "LeftFixedWedge",
-    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Left Fixed Wedge"),
+    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Left Inclined Plane"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "This is an immovable wedge.\nThe left is lower than the right, so things slide to the left."),
+                      "It’s a fixed obstacle with a tilted surface.\nThe left is higher than the right, so things slide to the right."),
     "usedwood-wedge-left",
     "(-0.5,-0.46)=(-0.5,-0.5)=(0.5,-0.5)=(0.5,0.5)",
     1.0, 1.0, 0.0, 0.1 );
 
 static AbstractPolyObjectFactory theRightFixedWedgeFactory(
     "RightFixedWedge",
-    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Right Fixed Wedge"),
+    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Right Inclined Plane"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "This is an immovable wedge.\nThe left is higher than the right, so things slide to the right."),
+                      "It’s a fixed obstacle with a tilted surface.\nThe left is higher than the right, so things slide to the right."),
     "usedwood-wedge-right",
     "(-0.5,0.5)=(-0.5,-0.5)=(0.5,-0.5)=(0.5,-0.46)",
     1.0, 1.0, 0.0, 0.1 );
@@ -154,9 +154,9 @@ static AbstractPolyObjectFactory theRightFixedWedgeFactory(
 // on both the inside and the outside - you can use both if you want :-)
 static AbstractPolyObjectFactory the40QuarterArcFactory(
     "QuarterArc40",
-    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Quarter Arc Small"),
+    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Small Quarter Arc"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "This quarter arc is attached to the scene.\nIt can't be moved, penetrated or destroyed."),
+                      "A quarter arc is a fixed obstacle\nand useful to divert things."),
     "QuarterArc",
     "(0.100,-.200)=(0.200,-.200)=(0.180,-.076)=(0.085,-.107);"
     "(0.085,-.107)=(0.180,-.076)=(0.124,0.035)=(0.043,-.024);"
@@ -169,9 +169,9 @@ static AbstractPolyObjectFactory the40QuarterArcFactory(
 // on both the inside and the outside - you can use both if you want :-)
 static AbstractPolyObjectFactory the80QuarterArcFactory(
     "QuarterArc80",
-    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Quarter Arc Large"),
+    QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Large Quarter Arc"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "This quarter arc is attached to the scene.\nIt can't be moved, penetrated or destroyed."),
+                      "A quarter arc is a fixed obstacle\nand useful to divert things."),
     "QuarterArc80",
     "( 0.300,-0.400)=( 0.400,-0.400)=( 0.388,-0.261)=( 0.289,-0.278);"
     "( 0.289,-0.278)=( 0.388,-0.261)=( 0.352,-0.126)=( 0.258,-0.161);"
@@ -220,7 +220,7 @@ static AbstractPolyObjectFactory theSmallSeesawFactory(
     "SeesawSmall",
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Small Seesaw"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "One usually puts toddlers on a seesaw, but they're in short supply."),
+                      "If this seesaw is pushed on one side,\nthe other side moves in the other direction."),
     "seesaw-tiny",
     "(-1.25,0.15)=(-1.25,0.01)=(1.25,0.01)=(1.25,0.15);"
     "(-1.25,0.01)=(-1.25,-0.15)=(-1.18,-0.15)=(-0.85,0.01);"

--- a/src/model/PolyObject.cpp
+++ b/src/model/PolyObject.cpp
@@ -136,7 +136,7 @@ static AbstractPolyObjectFactory theLeftFixedWedgeFactory(
     "LeftFixedWedge",
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Left Inclined Plane"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "It’s a fixed obstacle with a tilted surface.\nThe left is higher than the right, so things slide to the right."),
+                      "It’s a fixed obstacle with a tilted surface.\nThe left is lower than the right, so things slide to the left."),
     "usedwood-wedge-left",
     "(-0.5,-0.46)=(-0.5,-0.5)=(0.5,-0.5)=(0.5,0.5)",
     1.0, 1.0, 0.0, 0.1 );
@@ -145,7 +145,7 @@ static AbstractPolyObjectFactory theRightFixedWedgeFactory(
     "RightFixedWedge",
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory", "Right Inclined Plane"),
     QT_TRANSLATE_NOOP("AbstractPolyObjectFactory",
-                      "It’s a fixed obstacle with a tilted surface.\nThe left is lower than the right, so things slide to the left."),
+                      "It’s a fixed obstacle with a tilted surface.\nThe left is higher than the right, so things slide to the right."),
     "usedwood-wedge-right",
     "(-0.5,0.5)=(-0.5,-0.5)=(0.5,-0.5)=(0.5,-0.46)",
     1.0, 1.0, 0.0, 0.1 );

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -54,36 +54,36 @@ static RectObjectFactory theRectObjectFactory;
 
 // birch wood: 600 kg/m^3, i.e. a beam of 10cm x 10cm x 1.2m equals 7.2kg
 static AbstractRectObjectFactory theBirchBarFactory("BirchBar",
-                                                    QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Wooden Bar"),
+                                                    QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Birch Bar"),
                                                     QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
-                                                                      "Birch is a type of wood.\nBirch wood beams move and float."),
+                                                                      "Pieces of birch wood are movable and usually really heavy."),
                                                     "birch_bar", 1.0, 0.1, 7.2, 0.15 );
 
 static AbstractRectObjectFactory theStyrofoamFactory("Styrofoam",
                                                  QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Styrofoam Block"),
                                                  QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
-                                                                   "Styrofoam blocks are light and bouncy."),
+                                                                   "Styrofoam blocks are light and pretty bouncy."),
                                                  "styrofoam", 0.5, 0.25, 0.5, 0.6 );
 
 static AbstractRectObjectFactory theDomRedFactory("DominoRed",
                                                   QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Red)"),
-                                                  QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous red plastic domino stone."),
+                                                  QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "A red plastic domino, it can be toppled with ease."),
                                                   "DominoRed", 0.1, 0.5, 2.5, 0.1 );
 
 static AbstractRectObjectFactory theDomBlueFactory("DominoBlue",
                                                    QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Blue)"),
-                                                   QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous blue plastic domino stone."),
+                                                   QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "A blue plastic domino, it can be toppled with ease."),
                                                    "DominoBlue", 0.1, 0.5, 2.5, 0.1 );
 
 static AbstractRectObjectFactory theDomGreenFactory("DominoGreen",
                                                     QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Domino (Green)"),
-                                                    QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "The famous green plastic domino stone."),
+                                                    QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "A green plastic domino, it can be toppled with ease."),
                                                     "DominoGreen", 0.1, 0.5, 2.5, 0.1 );
 
 static AbstractRectObjectFactory theFloorFactory("Floor",
                                                  QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Floor"),
                                                  QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
-                                                                   "This is the floor. It is attached to the scene\nand can't be moved, penetrated or destroyed."),
+                                                                   "This is a floor, a fixed obstacle."),
                                                  "used_wood_bar", 1.0, 0.1, 0.0, 0.1 );
 
 // see http://www.saginawpipe.com/steel_i_beams.htm
@@ -91,13 +91,13 @@ static AbstractRectObjectFactory theFloorFactory("Floor",
 static AbstractRectObjectFactory theSteelHBeamFactory("IBeam",
                                                       QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Steel I-Beam"),
                                                       QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
-                                                                        "This is a steel I-beam. Steel I-beams are large and heavy\nand useful to build bridges and other constructions."),
+                                                                        "Steel I-beams are large and heavy\nand useful to build bridges and other constructions."),
                                                       "i-beam", 1.4, 0.1, 27.0, 0.0 );
 
 static AbstractRectObjectFactory theWallFactory("Wall",
                                                 QT_TRANSLATE_NOOP("AbstractRectObjectFactory", "Wall"),
                                                 QT_TRANSLATE_NOOP("AbstractRectObjectFactory",
-                                                                  "This is a brick wall. It is attached to the scene\nand can't be moved, penetrated or destroyed."),
+                                                                  "This is a brick wall, a fixed obstacle."),
                                                 "oldbrick", 0.2, 1.0, 0.0, 0.05 );
 
 // Note that this hammer is kind-of heavy, a normal hammer would be around 400 grams, only

--- a/src/model/TriggerExplosion.cpp
+++ b/src/model/TriggerExplosion.cpp
@@ -173,7 +173,7 @@ const QString DetonatorBox::getToolTip ( ) const
                                 "It triggers dynamite remotely if the handle is pushed.\n");
     QString part2;
     if (getCurrentPhoneNumber() == getEmptyString())
-        part2 = QObject::tr("This one doesn't make any calls yet,\nselect a phone number!");
+        part2 = QObject::tr("This one doesn’t make any calls yet,\nselect a phone number!");
     else
         //: Translators: The %1 will be replaced by a phone number.
         part2 = QObject::tr("This one calls %1.").arg(getCurrentPhoneNumber());
@@ -451,10 +451,10 @@ const QString Dynamite::getToolTip ( ) const
 {
     if (getID().isNull() || getID().isEmpty()) {
         //: Translators: “\n” means “newline”, keep it.
-        return QObject::tr("It's dynamite attached to a cell phone.\nThis cell phone doesn't take any calls, however.");
+        return QObject::tr("It’s dynamite attached to a cell phone.\nThis cell phone doesn’t take any calls, however.");
     } else {
         //: Translators: “\n” means “newline”, keep it. “%1” will be replaced by the phone number
-        return QObject::tr("It's dynamite attached to a cell phone, ready to be\nremotely triggered by a detonator box.\nDial %1 to make the dynamite go boom.").arg(
+        return QObject::tr("It’s dynamite attached to a cell phone, ready to be\nremotely triggered by a detonator box.\nDial %1 to make the dynamite go boom.").arg(
                    getID());
     }
 }


### PR DESCRIPTION
The updates follow the following scheme:

* Slightly more informative
* A bit less bla-bla
* Consistency in names and style
* Redundant default names removed
* Minor spelling fixes

Notable changes:
* Circular saw description now mentions that its dangerous to pingus
* The “fixed” wedges are now called “inclined plane”.
* All ball descriptions now describe weight and bounciness