### PR TITLE
Clean up visible properties in editor

### DIFF
--- a/src/model/AbstractObject.cpp
+++ b/src/model/AbstractObject.cpp
@@ -66,6 +66,7 @@ AbstractObject::AbstractObject(const QString &aTooltip,
     theProps.setDefaultPropertiesString(
         Property::IMAGE_NAME_STRING + QString(":%1/").arg(aImageName) +
         Property::BOUNCINESS_STRING + QString(":%1/").arg(theBounciness) +
+        Property::FRICTION_STRING + QString(":/") +
         Property::NOCOLLISION_STRING + QString(":/") +
         Property::ROTATABLE_STRING + QString(":false/") +
         Property::RESIZABLE_STRING + QString(":none/") +

--- a/src/model/AbstractObject.cpp
+++ b/src/model/AbstractObject.cpp
@@ -67,18 +67,24 @@ AbstractObject::AbstractObject(const QString &aTooltip,
         Property::IMAGE_NAME_STRING + QString(":%1/").arg(aImageName) +
         Property::BOUNCINESS_STRING + QString(":%1/").arg(theBounciness) +
         Property::NOCOLLISION_STRING + QString(":/") +
-        Property::PIVOTPOINT_STRING + QString(":/") +
         Property::ROTATABLE_STRING + QString(":false/") +
-        Property::TRANSLATIONGUIDE_STRING + QString(":/") +
+        Property::RESIZABLE_STRING + QString(":none/") +
         Property::ZVALUE_STRING + QString(":2.0/") );
-    // and overrule the default props set above if needed...
-    theProps.setDefaultPropertiesString(aPropertiesText);
 
     if (aMass > 0.001)
         theProps.setDefaultPropertiesString(
-            QString("%1:%2/").arg(Property::MASS_STRING).arg(QString::number(aMass)));
+            QString("%1:%2/").arg(Property::MASS_STRING).arg(QString::number(aMass)) +
+            QString("%1:/").arg(Property::PIVOTPOINT_STRING) +
+            QString("%1:/").arg(Property::TRANSLATIONGUIDE_STRING));
     else
+    {
         theProps.removeProperty(Property::MASS_STRING);
+        theProps.removeProperty(Property::PIVOTPOINT_STRING);
+        theProps.removeProperty(Property::TRANSLATIONGUIDE_STRING);
+    }
+
+    // and overrule the default props set above if needed...
+    theProps.setDefaultPropertiesString(aPropertiesText);
 }
 
 AbstractObject::~AbstractObject ( )

--- a/src/model/CircleObjects.cpp
+++ b/src/model/CircleObjects.cpp
@@ -92,6 +92,8 @@ CircleObject::CircleObject (const QString &aName,
 {
     DEBUG5ENTRY;
     createBallShapeFixture(aRadius, aMass);
+    theProps.setDefaultPropertiesString(
+        QString("%1:%2/").arg(Property::RADIUS_STRING, QString::number(aRadius)));
 }
 
 CircleObject::~CircleObject ( ) { }

--- a/src/model/Glue.cpp
+++ b/src/model/Glue.cpp
@@ -53,7 +53,13 @@ Glue::Glue() : AbstractJoint()
         Property::OBJECT1_STRING + QString(":/") +
         Property::OBJECT2_STRING + QString(":/") +
         Property::ZVALUE_STRING + QString(":5.0/") +
-        "-" + Property::MASS_STRING + ":/" );
+        "-" + Property::MASS_STRING + ":/"
+        "-" + Property::NOCOLLISION_STRING + ":/"
+        "-" + Property::PIVOTPOINT_STRING + ":/"
+        "-" + Property::ROTATABLE_STRING + ":/"
+        "-" + Property::RESIZABLE_STRING + ":/"
+        "-" + Property::TRANSLATIONGUIDE_STRING + ":/"
+        "-" + Property::BOUNCINESS_STRING + ":/" );
     DEBUG5("Glue::Glue() end");
 }
 

--- a/src/model/Glue.cpp
+++ b/src/model/Glue.cpp
@@ -54,6 +54,7 @@ Glue::Glue() : AbstractJoint()
         Property::OBJECT2_STRING + QString(":/") +
         Property::ZVALUE_STRING + QString(":5.0/") +
         "-" + Property::MASS_STRING + ":/"
+        "-" + Property::FRICTION_STRING + ":/" +
         "-" + Property::NOCOLLISION_STRING + ":/"
         "-" + Property::PIVOTPOINT_STRING + ":/"
         "-" + Property::ROTATABLE_STRING + ":/"

--- a/src/model/Link.cpp
+++ b/src/model/Link.cpp
@@ -52,6 +52,12 @@ Link::Link(void)
         Property::OBJECT2_STRING + QString(":/") +
         Property::OVERLAP_STRING + QString(":10/") +
         "-" + Property::MASS_STRING + ":/" +
+        "-" + Property::BOUNCINESS_STRING + ":/" +
+        "-" + Property::PIVOTPOINT_STRING + ":/" +
+        "-" + Property::ROTATABLE_STRING + ":/" +
+        "-" + Property::RESIZABLE_STRING + ":/" +
+        "-" + Property::TRANSLATIONGUIDE_STRING + ":/" +
+        "-" + Property::NOCOLLISION_STRING + ":/" +
         Property::ZVALUE_STRING + QString(":20.0/"));
 
 }

--- a/src/model/Link.cpp
+++ b/src/model/Link.cpp
@@ -53,6 +53,7 @@ Link::Link(void)
         Property::OVERLAP_STRING + QString(":10/") +
         "-" + Property::MASS_STRING + ":/" +
         "-" + Property::BOUNCINESS_STRING + ":/" +
+        "-" + Property::FRICTION_STRING + ":/" +
         "-" + Property::PIVOTPOINT_STRING + ":/" +
         "-" + Property::ROTATABLE_STRING + ":/" +
         "-" + Property::RESIZABLE_STRING + ":/" +

--- a/src/model/Pingus.cpp
+++ b/src/model/Pingus.cpp
@@ -588,6 +588,7 @@ PingusExit::PingusExit()
         Property::IMAGE_NAME_STRING + QString(":opendoor/") +
         Property::RESIZABLE_STRING + QString(":none/") +
         QString("-") + Property::BOUNCINESS_STRING + QString(":/") +
+        QString("-") + Property::FRICTION_STRING + QString(":/") +
         QString("-") + Property::NOCOLLISION_STRING + QString(":/") +
         QString("-") + Property::PIVOTPOINT_STRING + QString(":/") +
         QString("-") + Property::TRANSLATIONGUIDE_STRING + QString(":/") );

--- a/src/model/Pingus.cpp
+++ b/src/model/Pingus.cpp
@@ -44,6 +44,15 @@ Pingus::Pingus(const QString &anIconName)
                    "",
                    PINGUS_RADIUS, PINGUS_MASS, 0.0 ), theIconName(anIconName), theState(FALLING), theAnimationFrameIndex(0)
 {
+    theProps.setDefaultPropertiesString(
+        Property::FRICTION_STRING + QString(":/") +
+        QString("-") + Property::IMAGE_NAME_STRING + QString(":/") +
+        QString("-") + Property::FRICTION_STRING + QString(":/") +
+        QString("-") + Property::RADIUS_STRING + QString(":/") +
+        QString("-") + Property::ROTATABLE_STRING + QString(":false/") +
+        QString("-") + Property::RESIZABLE_STRING + QString(":false/") +
+        QString("-") + Property::PIVOTPOINT_STRING + QString(":/") +
+        QString("-") + Property::TRANSLATIONGUIDE_STRING + QString(":/") );
     updateViewPingus();
 }
 

--- a/src/model/PolyObject.cpp
+++ b/src/model/PolyObject.cpp
@@ -263,8 +263,7 @@ PolyObject::PolyObject( const QString &aDisplayName,
         Property::POLYGONS_STRING + QString(":") + anOutline + QString("/") +
         aDefaultPropertiesString + QString("/") );
 
-    float myFriction = 0.0;
-    if(!theProps.property2Float(Property::FRICTION_STRING, &myFriction))
+    if(theProps.doesPropertyExists(Property::FRICTION_STRING))
         theProps.setDefaultPropertiesString(Property::FRICTION_STRING + QString(":/"));
 
     // Make mass-related attributes for the generic object since those are hidden otherwise

--- a/src/model/PolyObject.cpp
+++ b/src/model/PolyObject.cpp
@@ -263,9 +263,6 @@ PolyObject::PolyObject( const QString &aDisplayName,
         Property::POLYGONS_STRING + QString(":") + anOutline + QString("/") +
         aDefaultPropertiesString + QString("/") );
 
-    if(theProps.doesPropertyExists(Property::FRICTION_STRING))
-        theProps.setDefaultPropertiesString(Property::FRICTION_STRING + QString(":/"));
-
     // Make mass-related attributes for the generic object since those are hidden otherwise
     if(aDisplayName == DEFAULT_POLYOBJECT_NAME)
     {

--- a/src/model/PolyObject.cpp
+++ b/src/model/PolyObject.cpp
@@ -266,6 +266,15 @@ PolyObject::PolyObject( const QString &aDisplayName,
     float myFriction = 0.0;
     if(!theProps.property2Float(Property::FRICTION_STRING, &myFriction))
         theProps.setDefaultPropertiesString(Property::FRICTION_STRING + QString(":/"));
+
+    // Make mass-related attributes for the generic object since those are hidden otherwise
+    if(aDisplayName == DEFAULT_POLYOBJECT_NAME)
+    {
+        theProps.setDefaultPropertiesString(
+            Property::MASS_STRING + QString(":/") +
+            Property::TRANSLATIONGUIDE_STRING + QString(":/") +
+            Property::PIVOTPOINT_STRING + QString(":/"));
+    }
 }
 
 

--- a/src/model/PolyObject.cpp
+++ b/src/model/PolyObject.cpp
@@ -260,9 +260,12 @@ PolyObject::PolyObject( const QString &aDisplayName,
     DEBUG5("PolyObject::PolyObject(%s, %f, %f)", ASCII(aDisplayName), aWidth, aHeight);
     theToolTip = aTooltip;
     theProps.setDefaultPropertiesString(
-        Property::FRICTION_STRING + QString(":/") +
         Property::POLYGONS_STRING + QString(":") + anOutline + QString("/") +
         aDefaultPropertiesString + QString("/") );
+
+    float myFriction = 0.0;
+    if(!theProps.property2Float(Property::FRICTION_STRING, &myFriction))
+        theProps.setDefaultPropertiesString(Property::FRICTION_STRING + QString(":/"));
 }
 
 

--- a/src/model/PostIt.cpp
+++ b/src/model/PostIt.cpp
@@ -56,6 +56,11 @@ PostIt::PostIt(const char *aDisplayName, const char *aTooltip, const QString &an
     theProps.setDefaultPropertiesString(
         Property::ZVALUE_STRING + QString(":1.5/") +
         Property::IMAGE_NAME_STRING + QString(":%1/").arg(theImageName) +
+        QString("page1:/page2:/page3:/page4:/page5:/page6:/page7:/page8:/page9:/") +
+        "-" + Property::BOUNCINESS_STRING + QString(":/") +
+        "-" + Property::NOCOLLISION_STRING + QString(":/") +
+        "-" + Property::ROTATABLE_STRING + QString(":/") +
+        "-" + Property::RESIZABLE_STRING + QString(":/") +
         "-" + Property::MASS_STRING + QString(":/") );
 
     DEBUG5("PostIt::PostIt done");

--- a/src/model/PostIt.cpp
+++ b/src/model/PostIt.cpp
@@ -58,6 +58,7 @@ PostIt::PostIt(const char *aDisplayName, const char *aTooltip, const QString &an
         Property::IMAGE_NAME_STRING + QString(":%1/").arg(theImageName) +
         QString("page1:/page2:/page3:/page4:/page5:/page6:/page7:/page8:/page9:/") +
         "-" + Property::BOUNCINESS_STRING + QString(":/") +
+        "-" + Property::FRICTION_STRING + QString(":/") +
         "-" + Property::NOCOLLISION_STRING + QString(":/") +
         "-" + Property::ROTATABLE_STRING + QString(":/") +
         "-" + Property::RESIZABLE_STRING + QString(":/") +

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -184,9 +184,9 @@ b2BodyType RectObject::getObjectType(void) const
 
 void RectObject::initRectAttributes ( )
 {
-    theProps.setDefaultPropertiesString(
-        Property::FRICTION_STRING    + QString(":/") +
-        Property::RESIZABLE_STRING   + QString(":") + Property::NONE_STRING + "/" );
+    float myFriction = 0.0;
+    if(!theProps.property2Float(Property::FRICTION_STRING, &myFriction))
+        theProps.setDefaultPropertiesString(Property::FRICTION_STRING + QString(":/"));
 }
 
 

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -190,8 +190,7 @@ b2BodyType RectObject::getObjectType(void) const
 
 void RectObject::initRectAttributes ( )
 {
-    float myFriction = 0.0;
-    if(!theProps.property2Float(Property::FRICTION_STRING, &myFriction))
+    if(theProps.doesPropertyExists(Property::FRICTION_STRING))
         theProps.setDefaultPropertiesString(Property::FRICTION_STRING + QString(":/"));
 }
 

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -137,6 +137,12 @@ RectObject::RectObject ( ) : AbstractObject(), theNameString(DEFAULT_RECTOBJECT_
     // because this object is very flexible and many parameters can be set through
     // the Properties, do not assume too much here...
 
+    // Make mass-related attributes for the generic object since those are hidden otherwise
+    theProps.setDefaultPropertiesString(
+        Property::MASS_STRING + QString(":/") +
+        Property::TRANSLATIONGUIDE_STRING + QString(":/") +
+        Property::PIVOTPOINT_STRING + QString(":/"));
+
     // also: keep in mind that child objects may set some things automatically
     initRectAttributes();
 }

--- a/src/model/RectObject.cpp
+++ b/src/model/RectObject.cpp
@@ -190,8 +190,6 @@ b2BodyType RectObject::getObjectType(void) const
 
 void RectObject::initRectAttributes ( )
 {
-    if(theProps.doesPropertyExists(Property::FRICTION_STRING))
-        theProps.setDefaultPropertiesString(Property::FRICTION_STRING + QString(":/"));
 }
 
 

--- a/src/model/Scenery.cpp
+++ b/src/model/Scenery.cpp
@@ -48,6 +48,8 @@ Scenery::Scenery( ) : AbstractObject()
         QString(":/-") + Property::FRICTION_STRING    +
         QString(":/-") + Property::PIVOTPOINT_STRING  +
         QString(":/-") + Property::RESIZABLE_STRING   +
+        QString(":/-") + Property::TRANSLATIONGUIDE_STRING   +
+        QString(":/-") + Property::NOCOLLISION_STRING   +
         QString(":/-") + Property::ROTATABLE_STRING   +
         QString(":/")  + Property::ZVALUE_STRING + ":0.1/" );
 


### PR DESCRIPTION
I noticed the list of available properties in the editor are pretty chaotic: Key properties were missing from many objects, while other objects had properties available which don't make sense for that object.

This PR aims to fix this by making sure the available properties make more or less sense. The properties were chosen by technical feasability, i.e. they have to work in the first place, not whether if it always make sense to use them.

But please check for yourself together with the objects test level `test-objects.xml`.